### PR TITLE
Fix RBS syntax

### DIFF
--- a/sig/json/repair.rbs
+++ b/sig/json/repair.rbs
@@ -3,5 +3,5 @@ module JSON
     VERSION: String
   end
 
-  def self.repair(String) -> ?String
+  def self.repair: (String) -> String?
 end


### PR DESCRIPTION
I don't know RBS but this was being parsed as invalid by the rbs gem version 3.9.5. This seems to be the correct syntax according to the [RBS documentation](https://github.com/ruby/rbs?tab=readme-ov-file#rbs).

I noticed this because it was causing my Solargraph installation to spam errors.