### PR TITLE
Add RBS validation and Steep typecheck to CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: Rspec, Rubocop & Steep
+name: Rspec, Rubocop, RBS & Steep
 
 on:
   push:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: Rspec & Rubocop
+name: Rspec, Rubocop & Steep
 
 on:
   push:
@@ -27,3 +27,7 @@ jobs:
       run: bundle exec rspec
     - name: Run rubocop
       run: bundle exec rubocop
+    - name: Validate RBS signatures
+      run: bundle exec rbs validate
+    - name: Run steep type check
+      run: bundle exec steep check

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,13 +5,13 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## Commands
 
 - `bin/setup` — install dependencies via Bundler.
-- `bundle exec rake` — default task; runs both RSpec and RuboCop.
+- `bundle exec rake` — default task; runs RSpec, RuboCop, and Steep.
 - `bundle exec rspec` — run the test suite.
 - `bundle exec rspec spec/json_spec.rb:42` — run a single example by line number; nearly all behavioral specs live in `spec/json_spec.rb`.
 - `bundle exec rubocop` — lint. Project-specific exclusions in `.rubocop.yml` deliberately disable several `Metrics/*` cops for `lib/json/repairer.rb` and `lib/json/repair/string_utils.rb` because the parser is long by design — don't try to "fix" it by chopping methods up.
 - `bin/console` — IRB with the gem preloaded.
 - `bundle exec rake install` / `bundle exec rake release` — local install / publish to rubygems.org.
-- Type checking: `Steepfile` checks `lib/` against `sig/`. Run `bundle exec steep check` if/when steep is installed (not in `Gemfile` by default).
+- Type checking: `Steepfile` checks `lib/` against `sig/`. `bundle exec steep check` (typecheck) and `bundle exec rbs validate` (sig syntax) both run in CI and as part of the default rake task. `steep` and `rbs` are dev dependencies in the `Gemfile`.
 
 Ruby `>= 3.0.0` is required (per gemspec). CI runs against Ruby 3.3.1.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## Commands
 
 - `bin/setup` — install dependencies via Bundler.
-- `bundle exec rake` — default task; runs RSpec, RuboCop, and Steep.
+- `bundle exec rake` — default task; runs RSpec, RuboCop, RBS validate, and Steep.
 - `bundle exec rspec` — run the test suite.
 - `bundle exec rspec spec/json_spec.rb:42` — run a single example by line number; nearly all behavioral specs live in `spec/json_spec.rb`.
 - `bundle exec rubocop` — lint. Project-specific exclusions in `.rubocop.yml` deliberately disable several `Metrics/*` cops for `lib/json/repairer.rb` and `lib/json/repair/string_utils.rb` because the parser is long by design — don't try to "fix" it by chopping methods up.

--- a/Gemfile
+++ b/Gemfile
@@ -10,3 +10,6 @@ gem 'rake', '~> 13.0'
 gem 'rspec', '~> 3.0'
 
 gem 'rubocop', '~> 1.21'
+
+gem 'rbs', '~> 3.4'
+gem 'steep', '~> 1.7'

--- a/Gemfile
+++ b/Gemfile
@@ -5,11 +5,11 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in json-repair.gemspec
 gemspec
 
-gem 'rake', '~> 13.0'
+group :development, :test do
+  gem 'rake', '~> 13.0'
+  gem 'rspec', '~> 3.0'
+  gem 'rubocop', '~> 1.21'
 
-gem 'rspec', '~> 3.0'
-
-gem 'rubocop', '~> 1.21'
-
-gem 'rbs', '~> 3.4'
-gem 'steep', '~> 1.7'
+  gem 'rbs', '~> 3.4'
+  gem 'steep', '~> 1.7'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,17 +6,56 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    activesupport (8.1.3)
+      base64
+      bigdecimal
+      concurrent-ruby (~> 1.0, >= 1.3.1)
+      connection_pool (>= 2.2.5)
+      drb
+      i18n (>= 1.6, < 2)
+      json
+      logger (>= 1.4.2)
+      minitest (>= 5.1)
+      securerandom (>= 0.3)
+      tzinfo (~> 2.0, >= 2.0.5)
+      uri (>= 0.13.1)
     ast (2.4.2)
+    base64 (0.3.0)
+    bigdecimal (4.1.2)
+    concurrent-ruby (1.3.6)
+    connection_pool (3.0.2)
+    csv (3.3.5)
     diff-lcs (1.5.1)
+    drb (2.2.3)
+    ffi (1.17.4)
+    ffi (1.17.4-arm64-darwin)
+    fileutils (1.8.0)
+    i18n (1.14.8)
+      concurrent-ruby (~> 1.0)
     json (2.7.2)
     language_server-protocol (3.17.0.3)
+    listen (3.10.0)
+      logger
+      rb-fsevent (~> 0.10, >= 0.10.3)
+      rb-inotify (~> 0.9, >= 0.9.10)
+    logger (1.7.0)
+    minitest (6.0.6)
+      drb (~> 2.0)
+      prism (~> 1.5)
     parallel (1.24.0)
     parser (3.3.1.0)
       ast (~> 2.4.1)
       racc
+    prism (1.9.0)
     racc (1.8.0)
     rainbow (3.1.1)
     rake (13.2.1)
+    rb-fsevent (0.11.2)
+    rb-inotify (0.11.1)
+      ffi (~> 1.0)
+    rbs (3.10.4)
+      logger
+      tsort
     regexp_parser (2.9.2)
     rexml (3.2.8)
       strscan (>= 3.0.9)
@@ -47,8 +86,31 @@ GEM
     rubocop-ast (1.31.3)
       parser (>= 3.3.1.0)
     ruby-progressbar (1.13.0)
+    securerandom (0.4.1)
+    steep (1.9.4)
+      activesupport (>= 5.1)
+      concurrent-ruby (>= 1.1.10)
+      csv (>= 3.0.9)
+      fileutils (>= 1.1.0)
+      json (>= 2.1.0)
+      language_server-protocol (>= 3.15, < 4.0)
+      listen (~> 3.0)
+      logger (>= 1.3.0)
+      parser (>= 3.1)
+      rainbow (>= 2.2.2, < 4.0)
+      rbs (~> 3.8)
+      securerandom (>= 0.1)
+      strscan (>= 1.0.0)
+      terminal-table (>= 2, < 4)
+      uri (>= 0.12.0)
     strscan (3.1.0)
+    terminal-table (3.0.2)
+      unicode-display_width (>= 1.1.1, < 3)
+    tsort (0.2.0)
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
     unicode-display_width (2.5.0)
+    uri (1.1.1)
 
 PLATFORMS
   arm64-darwin-23
@@ -57,8 +119,10 @@ PLATFORMS
 DEPENDENCIES
   json-repair!
   rake (~> 13.0)
+  rbs (~> 3.4)
   rspec (~> 3.0)
   rubocop (~> 1.21)
+  steep (~> 1.7)
 
 BUNDLED WITH
    2.5.10

--- a/Rakefile
+++ b/Rakefile
@@ -9,9 +9,14 @@ require 'rubocop/rake_task'
 
 RuboCop::RakeTask.new
 
+desc 'Validate RBS signatures in sig/'
+task :rbs do
+  sh 'bundle exec rbs validate'
+end
+
 desc 'Run Steep type check against sig/'
 task :steep do
   sh 'bundle exec steep check'
 end
 
-task default: %i[spec rubocop steep]
+task default: %i[spec rubocop rbs steep]

--- a/Rakefile
+++ b/Rakefile
@@ -9,4 +9,9 @@ require 'rubocop/rake_task'
 
 RuboCop::RakeTask.new
 
-task default: %i[spec rubocop]
+desc 'Run Steep type check against sig/'
+task :steep do
+  sh 'bundle exec steep check'
+end
+
+task default: %i[spec rubocop steep]

--- a/Steepfile
+++ b/Steepfile
@@ -3,4 +3,8 @@
 target :lib do
   signature 'sig'
   check 'lib'
+
+  library 'optparse'
+  library 'tempfile'
+  library 'fileutils'
 end

--- a/lib/json/repair/cli.rb
+++ b/lib/json/repair/cli.rb
@@ -34,7 +34,8 @@ module JSON
 
       def run(argv)
         positional = catch(:halt) { parser.parse(argv) }
-        return @halt if @halt
+        halt = @halt
+        return halt if halt
 
         input_path = positional.first
         return 1 unless validate(positional, input_path)
@@ -61,7 +62,7 @@ module JSON
       end
 
       def read_input(input_path)
-        raw = input_path ? File.read(input_path) : @stdin.read
+        raw = (input_path ? File.read(input_path) : @stdin.read).to_s
         raw.force_encoding(Encoding::UTF_8)
         raise JSON::JSONRepairError, 'input is not valid UTF-8' unless raw.valid_encoding?
 
@@ -69,10 +70,10 @@ module JSON
       end
 
       def write_output(repaired, input_path)
-        if @overwrite
+        if @overwrite && input_path
           replace_in_place(input_path, repaired)
-        elsif @output_path
-          File.write(@output_path, repaired)
+        elsif (output_path = @output_path)
+          File.write(output_path, repaired)
         else
           @stdout.write(repaired)
           @stdout.write("\n") unless repaired.end_with?("\n")

--- a/sig/json/repair/cli.rbs
+++ b/sig/json/repair/cli.rbs
@@ -1,9 +1,8 @@
 module JSON
   module Repair
     class CLI
-      # `::IO | ::StringIO` because `::StringIO` is not an `::IO` subclass; the
-      # specs inject `::StringIO` instances and any other duck-typed stream
-      # that implements `#read` / `#write` / `#puts` would work too.
+      # `::IO | ::StringIO` because `::StringIO` is not an `::IO` subclass
+      # and the specs inject `::StringIO` instances.
       type stream = ::IO | ::StringIO
 
       OVERWRITE_DESC: ::String

--- a/sig/json/repair/cli.rbs
+++ b/sig/json/repair/cli.rbs
@@ -6,11 +6,40 @@ module JSON
       # that implements `#read` / `#write` / `#puts` would work too.
       type stream = ::IO | ::StringIO
 
+      OVERWRITE_DESC: ::String
+
+      @stdin: stream
+      @stdout: stream
+      @stderr: stream
+      @output_path: ::String?
+      @halt: ::Integer?
+      @overwrite: bool
+
       def self.call: (::Array[::String] argv, ?stdin: stream, ?stdout: stream, ?stderr: stream) -> ::Integer
 
       def initialize: (?stdin: stream, ?stdout: stream, ?stderr: stream) -> void
 
       def call: (::Array[::String] argv) -> ::Integer
+
+      private
+
+      def run: (::Array[::String] argv) -> ::Integer
+
+      def validate: (::Array[::String] positional, ::String? input_path) -> bool
+
+      def validation_error: (::Array[::String] positional, ::String? input_path) -> ::String?
+
+      def read_input: (::String? input_path) -> ::String
+
+      def write_output: (::String repaired, ::String? input_path) -> void
+
+      def replace_in_place: (::String input_path, ::String repaired) -> void
+
+      def parser: () -> ::OptionParser
+
+      def define_options: (::OptionParser opts) -> void
+
+      def halt_with: (::String message) -> void
     end
   end
 end

--- a/sig/json/repair/cli.rbs
+++ b/sig/json/repair/cli.rbs
@@ -5,6 +5,9 @@ module JSON
       # and the specs inject `::StringIO` instances.
       type stream = ::IO | ::StringIO
 
+      # Marked `private_constant` in `lib/json/repair/cli.rb`. RBS has no
+      # `private_constant` syntax, so the declaration is unavoidably public
+      # in the signature; do not rely on it from outside this class.
       OVERWRITE_DESC: ::String
 
       @stdin: stream

--- a/sig/json/repairer.rbs
+++ b/sig/json/repairer.rbs
@@ -1,6 +1,15 @@
 module JSON
   class Repairer
-    @json: ::String
+    # `untyped` (not `::String`) because the parser idiomatically uses
+    # `@json[@index]` past EOF, relying on Ruby returning `nil` as a
+    # sentinel. Declaring `@json: ::String` makes steep infer `String?`
+    # from `String#[]` and rejects ~15 downstream call sites that pass
+    # the result to methods expecting `String`. Tightening would either
+    # require pervasive nil-extraction at every indexing site or a
+    # private accessor — both of which break parity with the upstream
+    # JS source (see CLAUDE.md and `.rubocop.yml` exceptions for
+    # `lib/json/repairer.rb`).
+    @json: untyped
 
     @index: Integer
 


### PR DESCRIPTION
## Summary

- Wires `bundle exec rbs validate` and `bundle exec steep check` into the GitHub Actions workflow and the default rake task, enforcing that `sig/` stays in sync with `lib/`.
- Brings `sig/json/repair/cli.rbs` to feature parity with the implementation (private methods, ivars, constants).
- Loosens `@json` in `sig/json/repairer.rbs` to `untyped` with an explanatory comment — the parser uses Ruby's `nil`-on-EOF behavior as a sentinel, and tightening to `::String` would force pervasive nil-handling that breaks parity with the upstream JS source (see `CLAUDE.md` and the existing `.rubocop.yml` exceptions for `lib/json/repairer.rb`).
- Three narrowing-only edits in `lib/json/repair/cli.rb` so steep can narrow `Integer?` / `String?` ivars without behavioral change.

## Test plan

- [x] `bundle exec rspec` — 119 examples, 0 failures
- [x] `bundle exec rubocop` — clean
- [x] `bundle exec rbs validate` — clean
- [x] `bundle exec steep check` — `No type error detected`
- [x] `bundle exec rake` (default) — all four pass
- [x] CI run on this PR confirms the same on Ruby 3.3.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)