### PR TITLE
Add return_objects: option to JSON.repair (0.6.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changes
 
+### 2026-05-12 (0.6.0)
+
+* `JSON.repair` accepts a `return_objects:` keyword argument. Pass
+  `return_objects: true` to receive the parsed Ruby value (Hash, Array,
+  or scalar) instead of a serialized JSON string. Default is `false`,
+  preserving the existing return-a-string contract. Mirrors Python's
+  `return_objects` option on
+  [`json_repair`](https://github.com/mangiucugna/json_repair).
+
 ### 2026-05-12 (0.5.0)
 
 * `JSON::JSONRepairError#position` returns the input index at which the

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    json-repair (0.5.0)
+    json-repair (0.6.0)
 
 GEM
   remote: https://rubygems.org/

--- a/README.md
+++ b/README.md
@@ -31,6 +31,13 @@ puts repaired_json  # Outputs: {"name": "Alice", "age": 25}
 
 The `repair` method takes a string containing JSON data and returns a corrected version of this string, ensuring it is valid JSON.
 
+Pass `return_objects: true` to get the parsed Ruby value (Hash, Array, or scalar) instead of a string:
+
+```ruby
+JSON.repair('{a: 1, b: [2, 3,]}', return_objects: true)
+# => {"a" => 1, "b" => [2, 3]}
+```
+
 ## Command line
 
 The gem ships a `json-repair` executable. It reads from stdin or a file and writes to stdout, `--output FILE`, or back over the input file with `--overwrite`.

--- a/Steepfile
+++ b/Steepfile
@@ -7,4 +7,5 @@ target :lib do
   library 'optparse'
   library 'tempfile'
   library 'fileutils'
+  library 'json'
 end

--- a/lib/json/repair.rb
+++ b/lib/json/repair.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'json'
+
 require_relative 'repair/version'
 require_relative 'repairer'
 
@@ -13,7 +15,8 @@ module JSON
     end
   end
 
-  def self.repair(json)
-    Repairer.new(json).repair
+  def self.repair(json, return_objects: false)
+    repaired = Repairer.new(json).repair
+    return_objects ? JSON.parse(repaired) : repaired
   end
 end

--- a/lib/json/repair/version.rb
+++ b/lib/json/repair/version.rb
@@ -2,6 +2,6 @@
 
 module JSON
   module Repair
-    VERSION = '0.5.0'
+    VERSION = '0.6.0'
   end
 end

--- a/sig/json/repair.rbs
+++ b/sig/json/repair.rbs
@@ -10,4 +10,6 @@ module JSON
   end
 
   def self.repair: (::String json) -> ::String
+                 | (::String json, return_objects: false) -> ::String
+                 | (::String json, return_objects: true) -> untyped
 end

--- a/spec/json_spec.rb
+++ b/spec/json_spec.rb
@@ -789,5 +789,54 @@ RSpec.describe JSON do
         end
       end
     end
+
+    context 'with return_objects: true' do
+      it 'returns a Hash for an object input' do
+        expect(JSON.repair('{"a": 1}', return_objects: true)).to eq({ 'a' => 1 })
+      end
+
+      it 'returns an Array for an array input' do
+        expect(JSON.repair('[1, 2, 3]', return_objects: true)).to eq([1, 2, 3])
+      end
+
+      it 'parses the repaired form, not the original broken input' do
+        expect(JSON.repair("{a: 'b', c: [1, 2,]}", return_objects: true))
+          .to eq({ 'a' => 'b', 'c' => [1, 2] })
+      end
+
+      it 'returns scalar values' do
+        expect(JSON.repair('true', return_objects: true)).to be(true)
+        expect(JSON.repair('null', return_objects: true)).to be_nil
+        expect(JSON.repair('42', return_objects: true)).to eq(42)
+        expect(JSON.repair('"hi"', return_objects: true)).to eq('hi')
+        expect(JSON.repair('""', return_objects: true)).to eq('')
+      end
+
+      it 'handles deeply nested structures' do
+        expect(JSON.repair('{"a":{"b":{"c":[1,2,[3,4]]}}}', return_objects: true))
+          .to eq({ 'a' => { 'b' => { 'c' => [1, 2, [3, 4]] } } })
+      end
+
+      it 'composes with heavy repairs (markdown fence + unquoted keys + smart quotes)' do
+        broken = "```json\n{name: “Alice”, age: 25}\n```"
+        expect(JSON.repair(broken, return_objects: true))
+          .to eq({ 'name' => 'Alice', 'age' => 25 })
+      end
+
+      it 'still raises JSONRepairError on unrecoverable input' do
+        expect { JSON.repair('', return_objects: true) }.to \
+          raise_error(JSON::JSONRepairError)
+      end
+    end
+
+    context 'with return_objects: false (default)' do
+      it 'returns the repaired string when omitted' do
+        expect(JSON.repair('{a: 1}')).to eq('{"a": 1}')
+      end
+
+      it 'returns the repaired string when explicitly false' do
+        expect(JSON.repair('{a: 1}', return_objects: false)).to eq('{"a": 1}')
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary

- `JSON.repair(str, return_objects: true)` returns the parsed Ruby value (Hash / Array / scalar) instead of a re-serialized JSON string. Default `false` preserves the existing string-returning contract.
- Mirrors Python's `return_objects` option on [`mangiucugna/json_repair`](https://github.com/mangiucugna/json_repair). Not in the JS upstream — explicit, sanctioned divergence per the local TODO.
- RBS overloads: the `false` (and omitted) case returns `::String`; the `true` case returns `untyped`, matching stdlib's own signature for `JSON.parse` (`(string, ?options) -> untyped`). `Steepfile` adds `library 'json'` so the call resolves.
- Version bumped 0.5.0 → 0.6.0.

## Test plan

- [x] `bundle exec rake` clean: 132 specs, 100% line + branch coverage (SimpleCov gate), RuboCop, `rbs validate`, `steep check` all green.
- [x] New specs in `spec/json_spec.rb` cover: Hash / Array / scalar returns, empty-string scalar, deeply nested structures, composition with heavy repairs (markdown fence + unquoted keys + smart quotes), default behavior unchanged, explicit `false` still returns string, unrecoverable input still raises `JSONRepairError`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)