### PR TITLE
Add benchmark-ips regression harness and rake bench task

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,6 +19,7 @@ Metrics/AbcSize:
 Metrics/MethodLength:
   Exclude:
     - lib/json/repairer.rb
+    - benchmark/**/*
 
 Metrics/CyclomaticComplexity:
   Exclude:

--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ group :development, :test do
   gem 'rspec', '~> 3.0'
   gem 'rubocop', '~> 1.21'
 
+  gem 'benchmark-ips', '~> 2.13'
   gem 'rbs', '~> 3.4'
   gem 'simplecov', '~> 0.22', require: false
   gem 'steep', '~> 1.7'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -21,6 +21,7 @@ GEM
       uri (>= 0.13.1)
     ast (2.4.2)
     base64 (0.3.0)
+    benchmark-ips (2.14.0)
     bigdecimal (4.1.2)
     concurrent-ruby (1.3.6)
     connection_pool (3.0.2)
@@ -124,6 +125,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  benchmark-ips (~> 2.13)
   json-repair!
   rake (~> 13.0)
   rbs (~> 3.4)

--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ Run `json-repair --help` for the full list of options.
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
 
+Run `bundle exec rake bench` for a `benchmark-ips` regression baseline across four canned scenarios (valid mixed JSON, broken LLM-style output, a large array, deeply nested objects). The harness lives under `benchmark/` and is not shipped in the published gem.
+
 To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and the created tag, and push the `.gem` file to [rubygems.org](https://rubygems.org).
 
 ## Contributing

--- a/Rakefile
+++ b/Rakefile
@@ -19,4 +19,9 @@ task :steep do
   sh 'bundle exec steep check'
 end
 
+desc 'Run benchmark/run.rb (regression baseline for JSON.repair)'
+task :bench do
+  ruby '-Ilib', 'benchmark/run.rb'
+end
+
 task default: %i[spec rubocop rbs steep]

--- a/benchmark/run.rb
+++ b/benchmark/run.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+# Benchmark harness for JSON.repair.
+#
+# Run with: bundle exec rake bench
+#
+# Reports operations/sec across four scenarios. Useful as a regression baseline
+# before perf work — record numbers from main, change something, re-run.
+
+require 'benchmark/ips'
+require 'json'
+require_relative '../lib/json/repair'
+
+# --- Inputs ----------------------------------------------------------------
+
+def sample_record(idx)
+  {
+    'id' => idx,
+    'name' => "user_#{idx}",
+    'email' => "user_#{idx}@example.com",
+    'active' => idx.even?,
+    'score' => idx * 1.5,
+    'tags' => %w[alpha beta gamma].first(idx % 3 + 1),
+    'meta' => {
+      'note' => "line one\nline two\ttab\t\"quoted\"",
+      'unicode' => "snowman ☃ emoji \u{1F600}",
+      'sci' => 1.23e-4,
+      'neg' => -idx,
+      'flag' => nil
+    }
+  }
+end
+
+VALID_MIXED = JSON.generate(
+  {
+    'users' => Array.new(20) { |i| sample_record(i) },
+    'page' => 1,
+    'total' => 20,
+    'has_more' => false
+  }
+)
+
+BROKEN_LLM_STYLE = <<~JSON
+  ```json
+  {
+    users: [
+      { 'id': 1, name: "Alice", "email": 'alice@example.com', tags: ["a", "b", "c",], active: True, },
+      { 'id': 2, name: "Bob",   "email": 'bob@example.com',   tags: ["d", "e",],      active: False, },
+      { 'id': 3, name: "Carol", "email": 'carol@example.com', tags: ["f",],           active: None, },
+    ],
+    // page info
+    page: 1,
+    total: 3,
+    note: "smart quotes “hi” and a trailing comma",
+  }
+  ```
+JSON
+
+LARGE_ARRAY = JSON.generate(Array.new(1_000) { |i| sample_record(i) })
+
+DEEPLY_NESTED = "#{'{"a":' * 50}1#{'}' * 50}".freeze
+
+SCENARIOS = {
+  'valid_mixed' => VALID_MIXED,
+  'broken_llm_style' => BROKEN_LLM_STYLE,
+  'large_array' => LARGE_ARRAY,
+  'deeply_nested' => DEEPLY_NESTED
+}.freeze
+
+# --- Sanity check ----------------------------------------------------------
+# Confirm every input round-trips through JSON.repair to valid JSON before we
+# spend ten seconds benching it. A bench result on garbage is worse than no
+# bench result.
+
+SCENARIOS.each do |name, input|
+  repaired = JSON.repair(input)
+  JSON.parse(repaired)
+  puts format(
+    '%<name>-18s %<in>6d bytes in → %<out>6d bytes out',
+    name: name, in: input.bytesize, out: repaired.bytesize
+  )
+rescue StandardError => e
+  abort "scenario #{name.inspect} failed sanity check: #{e.class}: #{e.message}"
+end
+puts
+
+# --- Benchmarks ------------------------------------------------------------
+
+Benchmark.ips do |x|
+  SCENARIOS.each do |name, input|
+    x.report(name) { JSON.repair(input) }
+  end
+  x.compare!
+end

--- a/json-repair.gemspec
+++ b/json-repair.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.files = IO.popen(%w[git ls-files -z], chdir: __dir__, err: IO::NULL) do |ls|
     ls.readlines("\x0", chomp: true).reject do |f|
       (f == gemspec) ||
-        f.start_with?(*%w[bin/ test/ spec/ features/ .git .github appveyor Gemfile])
+        f.start_with?(*%w[bin/ test/ spec/ features/ benchmark/ .git .github appveyor Gemfile])
     end
   end
   spec.bindir = 'exe'


### PR DESCRIPTION
## Summary
- Adds `benchmark/run.rb`: four `benchmark-ips` scenarios (valid mixed JSON, LLM-style broken payload, 1 000-record large array, 50-level deeply nested object). Each input is round-tripped through `JSON.repair` + `JSON.parse` before benching so a broken fixture fails loudly instead of producing nonsense numbers.
- Wires `bundle exec rake bench` and adds `benchmark-ips` to the dev/test group.
- Excludes `benchmark/` from the packaged gem; excludes `benchmark/**/*` from `Metrics/MethodLength`.

## Why
TODO item from `TODO.md` Tier 2 — gives us a regression baseline before any perf work. The first run on an M-series Mac already surfaces a likely O(n²) in `@output` tail-rewriting: `large_array` (240 KB) takes 13.6 s per repair while `deeply_nested` does 3.7 k i/s. Not addressed in this PR — that's the point of having a harness.

## Sample output
```
valid_mixed          4689 bytes in →   4689 bytes out
broken_llm_style      428 bytes in →    424 bytes out
large_array        239645 bytes in → 239645 bytes out
deeply_nested         301 bytes in →    301 bytes out

         valid_mixed    118.7 i/s
    broken_llm_style    2.9k  i/s
         large_array    0.073 i/s
       deeply_nested    3.7k  i/s
```

## Test plan
- [x] `bundle exec rake bench` runs to completion and prints the comparison table
- [x] `bundle exec rake` (rspec + rubocop + rbs + steep) is green
- [x] `Gem::Specification.load('json-repair.gemspec').files.grep(%r{benchmark/})` returns `[]` — harness does not ship in the published gem

🤖 Generated with [Claude Code](https://claude.com/claude-code)