### PR TITLE
Tighten RBS signatures to replace `untyped`

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -19,6 +19,9 @@ task :steep do
   sh 'bundle exec steep check'
 end
 
+desc 'Type-check: rbs validate + steep check'
+task typecheck: %i[rbs steep]
+
 desc 'Run benchmark/run.rb (regression baseline for JSON.repair)'
 task :bench do
   ruby '-Ilib', 'benchmark/run.rb'

--- a/lib/json/repair/string_utils.rb
+++ b/lib/json/repair/string_utils.rb
@@ -143,7 +143,12 @@ module JSON
         !char.nil? && [QUOTE, QUOTE_LEFT, QUOTE_RIGHT, GRAVE_ACCENT, ACUTE_ACCENT].include?(char)
       end
 
-      # Strip last occurrence of text_to_strip from text
+      # Strip last occurrence of text_to_strip from text.
+      #
+      # `|| ''` on the slices below (and in `insert_before_last_whitespace` /
+      # `remove_at_index`) is for steep's nil-narrowing: `String#[range]` is
+      # typed `String?`, but every call site here keeps indices within
+      # `0..text.length`, so the slices never actually return `nil`.
       def strip_last_occurrence(text, text_to_strip, strip_remaining_text: false)
         index = text.rindex(text_to_strip)
         return text unless index

--- a/lib/json/repair/string_utils.rb
+++ b/lib/json/repair/string_utils.rb
@@ -60,13 +60,14 @@ module JSON
 
       # Functions to check character chars
       def hex?(char)
-        (char >= ZERO && char <= NINE) ||
-          (char >= UPPERCASE_A && char <= UPPERCASE_F) ||
-          (char >= LOWERCASE_A && char <= LOWERCASE_F)
+        !char.nil? &&
+          ((char >= ZERO && char <= NINE) ||
+           (char >= UPPERCASE_A && char <= UPPERCASE_F) ||
+           (char >= LOWERCASE_A && char <= LOWERCASE_F))
       end
 
       def digit?(char)
-        char && char >= ZERO && char <= NINE
+        !char.nil? && char >= ZERO && char <= NINE
       end
 
       def valid_string_character?(char)
@@ -74,11 +75,11 @@ module JSON
       end
 
       def delimiter?(char)
-        REGEX_DELIMITER.match?(char)
+        !char.nil? && REGEX_DELIMITER.match?(char)
       end
 
       def unquoted_string_delimiter?(char)
-        REGEX_UNQUOTED_STRING_DELIMITER.match?(char)
+        !char.nil? && REGEX_UNQUOTED_STRING_DELIMITER.match?(char)
       end
 
       REGEX_FUNCTION_NAME_CHAR_START = /\A[a-zA-Z_$]\z/
@@ -93,19 +94,19 @@ module JSON
       end
 
       def start_of_value?(char)
-        REGEX_START_OF_VALUE.match?(char) || (char && quote?(char))
+        !char.nil? && (REGEX_START_OF_VALUE.match?(char) || quote?(char))
       end
 
       def control_character?(char)
-        [NEWLINE, RETURN, TAB, BACKSPACE, FORM_FEED].include?(char)
+        !char.nil? && [NEWLINE, RETURN, TAB, BACKSPACE, FORM_FEED].include?(char)
       end
 
       def whitespace?(char)
-        [SPACE, NEWLINE, TAB, RETURN].include?(char)
+        !char.nil? && [SPACE, NEWLINE, TAB, RETURN].include?(char)
       end
 
       def whitespace_except_newline?(char)
-        [SPACE, TAB, RETURN].include?(char)
+        !char.nil? && [SPACE, TAB, RETURN].include?(char)
       end
 
       def special_whitespace?(char)
@@ -135,11 +136,11 @@ module JSON
       end
 
       def double_quote_like?(char)
-        [DOUBLE_QUOTE, DOUBLE_QUOTE_LEFT, DOUBLE_QUOTE_RIGHT].include?(char)
+        !char.nil? && [DOUBLE_QUOTE, DOUBLE_QUOTE_LEFT, DOUBLE_QUOTE_RIGHT].include?(char)
       end
 
       def single_quote_like?(char)
-        [QUOTE, QUOTE_LEFT, QUOTE_RIGHT, GRAVE_ACCENT, ACUTE_ACCENT].include?(char)
+        !char.nil? && [QUOTE, QUOTE_LEFT, QUOTE_RIGHT, GRAVE_ACCENT, ACUTE_ACCENT].include?(char)
       end
 
       # Strip last occurrence of text_to_strip from text
@@ -147,8 +148,8 @@ module JSON
         index = text.rindex(text_to_strip)
         return text unless index
 
-        remaining_text = strip_remaining_text ? '' : text[index + 1..]
-        text[0...index] + remaining_text
+        remaining_text = strip_remaining_text ? '' : (text[index + 1..] || '')
+        (text[0...index] || '') + remaining_text
       end
 
       def insert_before_last_whitespace(text, text_to_insert)
@@ -158,7 +159,7 @@ module JSON
 
         index -= 1 while whitespace?(text[index - 1])
 
-        text[0...index] + text_to_insert + text[index..]
+        (text[0...index] || '') + text_to_insert + (text[index..] || '')
       end
 
       # Parse keywords true, false, null
@@ -187,7 +188,7 @@ module JSON
       end
 
       def remove_at_index(text, start, count)
-        text[0...start] + text[start + count..]
+        (text[0...start] || '') + (text[start + count..] || '')
       end
 
       def ends_with_comma_or_newline?(text)

--- a/sig/json/repair.rbs
+++ b/sig/json/repair.rbs
@@ -1,4 +1,10 @@
 module JSON
+  # Recursive type for any `JSON.parse` result. Mirrors what stdlib's
+  # `JSON.parse` produces (and the JS upstream emits): scalars, arrays,
+  # and objects of the same. Used in place of `untyped` for the
+  # `return_objects: true` and internal `*_parse` paths.
+  type json_value = ::Hash[::String, json_value] | ::Array[json_value] | ::String | ::Integer | ::Float | bool | nil
+
   class JSONRepairError < StandardError
     attr_reader position: ::Integer?
 
@@ -10,12 +16,12 @@ module JSON
   end
 
   def self.repair: (::String json, return_objects: false, ?skip_json_loads: bool) -> ::String
-                 | (::String json, return_objects: true, ?skip_json_loads: bool) -> untyped
+                 | (::String json, return_objects: true, ?skip_json_loads: bool) -> json_value
                  | (::String json, ?skip_json_loads: bool) -> ::String
 
   private
 
-  def self.tolerant_parse: (::String json) -> untyped
+  def self.tolerant_parse: (::String json) -> json_value
 
-  def self.repaired_parse: (::String json) -> untyped
+  def self.repaired_parse: (::String json) -> json_value
 end

--- a/sig/json/repair/string_utils.rbs
+++ b/sig/json/repair/string_utils.rbs
@@ -1,9 +1,9 @@
 module JSON
   module Repair
     module StringUtils
-      @output: untyped
+      @output: ::String
 
-      @index: untyped
+      @index: ::Integer
 
       # Constants for character chars
       BACKSLASH: "\\"
@@ -24,17 +24,17 @@ module JSON
 
       CLOSE_PARENTHESIS: ")"
 
-      SPACE: " "
+      SPACE: ::String
 
-      NEWLINE: "\n"
+      NEWLINE: ::String
 
-      TAB: "\t"
+      TAB: ::String
 
-      RETURN: "\r"
+      RETURN: ::String
 
-      BACKSPACE: "\b"
+      BACKSPACE: ::String
 
-      FORM_FEED: "\f"
+      FORM_FEED: ::String
 
       DOUBLE_QUOTE: "\""
 
@@ -110,56 +110,60 @@ module JSON
 
       REGEX_FUNCTION_NAME_CHAR: ::Regexp
 
-      # Functions to check character chars
-      def hex?: (untyped char) -> untyped
+      # Functions to check character chars.
+      # `char` is `::String?` because every caller passes `@json[@index]`,
+      # which is `nil` past the end of input. The predicates either guard
+      # against `nil` explicitly or rely on `Array#include?` / `==` /
+      # `Regexp#match?` returning a safe value for `nil`.
+      def hex?: (::String? char) -> bool
 
-      def digit?: (untyped char) -> untyped
+      def digit?: (::String? char) -> bool
 
-      def valid_string_character?: (untyped char) -> untyped
+      def valid_string_character?: (::String char) -> bool
 
-      def delimiter?: (untyped char) -> untyped
+      def delimiter?: (::String? char) -> bool
 
-      def unquoted_string_delimiter?: (untyped char) -> untyped
+      def unquoted_string_delimiter?: (::String? char) -> bool
 
-      def function_name_char_start?: (untyped char) -> untyped
+      def function_name_char_start?: (::String? char) -> bool
 
-      def function_name_char?: (untyped char) -> untyped
+      def function_name_char?: (::String? char) -> bool
 
-      def start_of_value?: (untyped char) -> untyped
+      def start_of_value?: (::String? char) -> bool
 
-      def control_character?: (untyped char) -> untyped
+      def control_character?: (::String? char) -> bool
 
-      def whitespace?: (untyped char) -> untyped
+      def whitespace?: (::String? char) -> bool
 
-      def whitespace_except_newline?: (untyped char) -> untyped
+      def whitespace_except_newline?: (::String? char) -> bool
 
-      def special_whitespace?: (untyped char) -> untyped
+      def special_whitespace?: (::String? char) -> bool
 
-      def quote?: (untyped char) -> untyped
+      def quote?: (::String? char) -> bool
 
-      def double_quote?: (untyped char) -> untyped
+      def double_quote?: (::String? char) -> bool
 
-      def single_quote?: (untyped char) -> untyped
+      def single_quote?: (::String? char) -> bool
 
-      def double_quote_like?: (untyped char) -> untyped
+      def double_quote_like?: (::String? char) -> bool
 
-      def single_quote_like?: (untyped char) -> untyped
+      def single_quote_like?: (::String? char) -> bool
 
       # Strip last occurrence of text_to_strip from text
-      def strip_last_occurrence: (untyped text, untyped text_to_strip, ?strip_remaining_text: bool) -> untyped
+      def strip_last_occurrence: (::String text, ::String text_to_strip, ?strip_remaining_text: bool) -> ::String
 
-      def insert_before_last_whitespace: (untyped text, untyped text_to_insert) -> untyped
+      def insert_before_last_whitespace: (::String text, ::String text_to_insert) -> ::String
 
       # Parse keywords true, false, null
       # Repair Python keywords True, False, None
       # Repair Ruby keyword nil
-      def parse_keywords: () -> untyped
+      def parse_keywords: () -> bool
 
-      def parse_keyword: (untyped name, untyped value) -> (true | false)
+      def parse_keyword: (::String name, ::String value) -> bool
 
-      def remove_at_index: (untyped text, untyped start, untyped count) -> untyped
+      def remove_at_index: (::String text, ::Integer start, ::Integer count) -> ::String
 
-      def ends_with_comma_or_newline?: (untyped text) -> untyped
+      def ends_with_comma_or_newline?: (::String text) -> bool
     end
   end
 end

--- a/sig/json/repairer.rbs
+++ b/sig/json/repairer.rbs
@@ -11,7 +11,7 @@ module JSON
     # `lib/json/repairer.rb`).
     @json: untyped
 
-    @index: Integer
+    @index: ::Integer
 
     @output: ::String
 
@@ -31,25 +31,25 @@ module JSON
 
     private
 
-    def parse_value: () -> untyped
+    def parse_value: () -> bool
 
-    def parse_whitespace: (?skip_newline: bool) -> (true | false)
+    def parse_whitespace: (?skip_newline: bool) -> bool
 
-    def parse_comment: () -> (true | false)
+    def parse_comment: () -> bool
 
     # Find and skip over a Markdown fenced code block
-    def parse_markdown_code_block: (::Array[::String] blocks) -> (true | false)
+    def parse_markdown_code_block: (::Array[::String] blocks) -> bool
 
-    def skip_markdown_code_block: (::Array[::String] blocks) -> (true | false)
+    def skip_markdown_code_block: (::Array[::String] blocks) -> bool
 
     # Parse an object like '{"key": "value"}'
-    def parse_object: () -> (false | true)
+    def parse_object: () -> bool
 
-    def skip_character: (untyped char) -> (true | false)
+    def skip_character: (::String char) -> bool
 
     # Skip ellipsis like "[1,2,3,...]" or "[1,2,3,...,9]" or "[...,7,8,9]"
     # or a similar construct in objects.
-    def skip_ellipsis: () -> untyped
+    def skip_ellipsis: () -> void
 
     # Parse a string enclosed by double quotes "...". Can contain escaped quotes
     # Repair strings enclosed in single quotes or special quotes
@@ -62,51 +62,55 @@ module JSON
     #   more conservative way, stopping the string at the first next delimiter
     #   and fixing the string by inserting a quote there, or stopping at a
     #   stop index detected in the first iteration.
-    def parse_string: (?stop_at_delimiter: bool, ?stop_at_index: ::Integer) -> (untyped | true | false)
+    def parse_string: (?stop_at_delimiter: bool, ?stop_at_index: ::Integer) -> bool
 
     # Repair an unquoted string by adding quotes around it
     # Repair a MongoDB function call like NumberLong("2")
     # Repair a JSONP function call like callback({...});
-    def parse_unquoted_string: (bool is_key) -> (false | true)
+    def parse_unquoted_string: (bool is_key) -> bool
 
     # Parse a regular expression literal like /foo/ or /foo\/bar/
-    def parse_regex: () -> (false | true)
+    def parse_regex: () -> bool
 
-    def parse_character: (untyped char) -> (true | false)
+    def parse_character: (::String char) -> bool
 
-    def parse_whitespace_and_skip_comments: (?skip_newline: bool) -> untyped
+    def parse_whitespace_and_skip_comments: (?skip_newline: bool) -> bool
 
     # Parse a number like 2.4 or 2.4e6
-    def parse_number: () -> (true | false)
+    def parse_number: () -> bool
 
-    def at_end_of_number?: () -> untyped
+    def at_end_of_number?: () -> bool
 
     # Parse an array like '["item1", "item2", ...]'
-    def parse_array: () -> (true | false)
+    def parse_array: () -> bool
 
-    def prev_non_whitespace_index: (untyped start) -> untyped
+    def prev_non_whitespace_index: (::Integer start) -> ::Integer
 
     # Repair concatenated strings like "hello" + "world", change this into "helloworld"
-    def parse_concatenated_string: () -> untyped
+    def parse_concatenated_string: () -> bool
 
-    def repair_number_ending_with_numeric_symbol: (untyped start) -> untyped
+    def repair_number_ending_with_numeric_symbol: (::Integer start) -> void
 
     # Parse and repair Newline Delimited JSON (NDJSON):
     # multiple JSON objects separated by a newline character
-    def parse_newline_delimited_json: () -> untyped
+    def parse_newline_delimited_json: () -> void
 
-    def skip_escape_character: () -> untyped
+    def skip_escape_character: () -> bool
 
-    def throw_invalid_character: (untyped char) -> untyped
+    # `bot` (bottom) because these always raise — steep needs this to
+    # treat their call sites as unreachable so methods like `repair`
+    # type-check (the trailing `throw_unexpected_character` must not
+    # contribute `void` to the method's union return type).
+    def throw_invalid_character: (::String char) -> bot
 
-    def throw_unexpected_character: () -> untyped
+    def throw_unexpected_character: () -> bot
 
-    def throw_unexpected_end: () -> untyped
+    def throw_unexpected_end: () -> bot
 
-    def throw_object_key_expected: () -> untyped
+    def throw_object_key_expected: () -> bot
 
-    def throw_colon_expected: () -> untyped
+    def throw_colon_expected: () -> bot
 
-    def throw_invalid_unicode_character: () -> untyped
+    def throw_invalid_unicode_character: () -> bot
   end
 end


### PR DESCRIPTION
## Summary
- Replaces all **66** method-level `untyped` annotations across `sig/` with concrete types. Exactly **one** intentional `untyped` remains: `@json` on `Repairer`, documented in-file (the parser indexes past EOF and uses `nil` as a sentinel; tightening would force pervasive nil-extraction and break parity with the JS upstream).
- Adds `type json_value = ::Hash[::String, json_value] | ::Array[json_value] | ::String | ::Integer | ::Float | bool | nil` and uses it for the `return_objects: true` overload of `JSON.repair` and the private `*_parse` classmethods.
- Tiny, behavior-preserving tweaks to `lib/json/repair/string_utils.rb` (added `!char.nil? &&` guards and `|| ''` slice fallbacks) so steep can narrow `String?` to `String`.

## Notable typing choices
- `throw_*` helpers on `Repairer` are typed `bot` (bottom) rather than `void`. Without this, the trailing `throw_unexpected_character` in `repair` bleeds `void` into its declared `::String` return.
- Six single-char constants (`SPACE`, `NEWLINE`, `TAB`, `RETURN`, `BACKSPACE`, `FORM_FEED`) widened from literal types to `::String` so `Array#include?` accepts a narrowed `::String` argument. Literal types stayed on every other constant.
- `digit?` returns `bool` instead of the prior `bool?` (rewrote `char && …` to `!char.nil? && …`).

## Test plan
- [x] `bundle exec rake` — spec + rubocop + rbs validate + steep check, all green.
- [x] `bundle exec rspec` — 143 examples, 0 failures.
- [x] SimpleCov — 100% line and branch coverage retained (584/584 line, 226/226 branch).
- [x] `bundle exec steep check` reports "No type error detected."
- [x] `bundle exec rbs validate` reports "17 files inspected, no offenses detected."

🤖 Generated with [Claude Code](https://claude.com/claude-code)