### PR TITLE
Repair leading-dot numbers like .5 (0.9.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changes
 
+### 2026-06-11 (0.9.0)
+
+* Repair numbers missing the digit before their decimal point:
+  `.5` → `0.5`, `-.5` → `-0.5`, and truncated forms like `.` → `0.0`.
+  Previously these leaked a raw stdlib `JSON::ParserError` out of
+  `JSON.repair` because the repairer emitted the leading-dot number
+  unchanged (invalid JSON) and the canonical-output re-parse choked on
+  it. This is a deliberate divergence from upstream
+  [jsonrepair](https://github.com/josdejong/jsonrepair) (which leaves
+  leading-dot numbers unrepaired as of v3.14.0), matching
+  [dirty-json](https://github.com/RyanMarcus/dirty-json) behavior.
+* `JSON.repair` now guards its error contract: if the repairer ever
+  emits a string stdlib JSON cannot parse (a repairer bug), the stdlib
+  error is wrapped in `JSON::JSONRepairError` instead of leaking
+  `JSON::ParserError` to callers.
+
 ### 2026-05-15 (0.8.0)
 
 * `JSON.repair_file(path)` and `JSON.repair_io(io)` convenience

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    json-repair (0.8.0)
+    json-repair (0.9.0)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/json/repair.rb
+++ b/lib/json/repair.rb
@@ -43,8 +43,14 @@ module JSON
   end
   private_class_method :tolerant_parse
 
+  # The rescue guards the JSONRepairError-only error contract: if the
+  # Repairer ever emits a string stdlib JSON cannot parse (a Repairer bug),
+  # wrap the stdlib error instead of leaking JSON::ParserError to callers.
   def self.repaired_parse(json)
-    JSON.parse(Repairer.new(json).repair)
+    repaired = Repairer.new(json).repair
+    JSON.parse(repaired)
+  rescue JSON::ParserError => e
+    raise JSONRepairError, "Internal error: repaired output is not valid JSON (#{e.message})"
   end
   private_class_method :repaired_parse
 end

--- a/lib/json/repair/version.rb
+++ b/lib/json/repair/version.rb
@@ -2,6 +2,6 @@
 
 module JSON
   module Repair
-    VERSION = '0.8.0'
+    VERSION = '0.9.0'
   end
 end

--- a/lib/json/repairer.rb
+++ b/lib/json/repairer.rb
@@ -718,8 +718,12 @@ module JSON
 
     # Repair a number missing its digit before the decimal point, like ".5"
     # or "-.5", into "0.5" / "-0.5". Divergence from upstream, which emits
-    # the invalid leading-dot number unchanged.
+    # the invalid leading-dot number unchanged. The guard keeps the common
+    # case (a number that needs no repair) allocation-free; `sub` copies
+    # its receiver even when the pattern does not match.
     def repair_leading_dot_number(num)
+      return num unless num.start_with?('.', '-.')
+
       num.sub(/\A(?<sign>-?)\./, '\k<sign>0.')
     end
 

--- a/lib/json/repairer.rb
+++ b/lib/json/repairer.rb
@@ -570,7 +570,9 @@ module JSON
           repair_number_ending_with_numeric_symbol(start)
           return true
         end
-        unless digit?(@json[@index])
+        # also accept a dot so "-.5" continues into the fraction branch
+        # below (divergence from upstream, which leaves "-.5" unrepaired)
+        unless digit?(@json[@index]) || @json[@index] == DOT
           @index = start
           return false
         end
@@ -620,7 +622,7 @@ module JSON
         num = @json[start...@index]
         has_invalid_leading_zero = num.match?(/^0\d/)
 
-        @output << (has_invalid_leading_zero ? "\"#{num}\"" : num)
+        @output << (has_invalid_leading_zero ? "\"#{num}\"" : repair_leading_dot_number(num))
         return true
       end
 
@@ -711,7 +713,14 @@ module JSON
       # repair numbers cut off at the end
       # this will only be called when we end after a '.', '-', or 'e' and does not
       # change the number more than it needs to make it valid JSON
-      @output << "#{@json[start...@index]}0"
+      @output << repair_leading_dot_number("#{@json[start...@index]}0")
+    end
+
+    # Repair a number missing its digit before the decimal point, like ".5"
+    # or "-.5", into "0.5" / "-0.5". Divergence from upstream, which emits
+    # the invalid leading-dot number unchanged.
+    def repair_leading_dot_number(num)
+      num.sub(/\A(?<sign>-?)\./, '\k<sign>0.')
     end
 
     # Parse and repair Newline Delimited JSON (NDJSON):

--- a/sig/json/repairer.rbs
+++ b/sig/json/repairer.rbs
@@ -91,6 +91,10 @@ module JSON
 
     def repair_number_ending_with_numeric_symbol: (::Integer start) -> void
 
+    # Repair a number missing its digit before the decimal point, like ".5"
+    # or "-.5", into "0.5" / "-0.5".
+    def repair_leading_dot_number: (::String num) -> ::String
+
     # Parse and repair Newline Delimited JSON (NDJSON):
     # multiple JSON objects separated by a newline character
     def parse_newline_delimited_json: () -> void

--- a/spec/json_spec.rb
+++ b/spec/json_spec.rb
@@ -674,6 +674,23 @@ RSpec.describe JSON do
         expect(JSON.repair('[0789]')).to eq('["0789"]')
         expect(JSON.repair('{value:0789}')).to eq('{"value":"0789"}')
       end
+
+      it 'repairs a number starting with a dot' do
+        expect(JSON.repair('.5')).to eq('0.5')
+        expect(JSON.repair('-.5')).to eq('-0.5')
+        expect(JSON.repair('[.5, .25]')).to eq('[0.5,0.25]')
+        expect(JSON.repair('{"a": .5}')).to eq('{"a":0.5}')
+        expect(JSON.repair('.5e2')).to eq('50.0')
+      end
+
+      it 'repairs a number cut off after a leading dot' do
+        expect(JSON.repair('.')).to eq('0.0')
+        expect(JSON.repair('[-., 1]')).to eq('[-0.0,1]')
+      end
+
+      it 'repairs an object with an unquoted key and unclosed array value' do
+        expect(JSON.repair('{foo: [}')).to eq('{"foo":[]}')
+      end
     end
 
     context 'when the JSON cannot be repaired' do
@@ -777,6 +794,20 @@ RSpec.describe JSON do
           expect(err.position).to eq(5)
           expect(err.message).to eq('JSON::JSONRepairError')
         end
+      end
+    end
+
+    context 'when the repairer emits output stdlib cannot parse' do
+      # No known input triggers this today; the stub stands in for a future
+      # repairer bug so the JSONRepairError-only error contract holds even
+      # if one slips in.
+      it 'wraps the stdlib parser error in JSONRepairError' do
+        repairer = instance_double(JSON::Repairer, repair: '{"a":')
+        allow(JSON::Repairer).to receive(:new).and_return(repairer)
+
+        expect { JSON.repair('{"a":') }.to raise_error(
+          JSON::JSONRepairError, /repaired output is not valid JSON/
+        )
       end
     end
 


### PR DESCRIPTION
## Summary

- `JSON.repair('.5')` (and `[.5, .25]`, `{"a": .5}`, `-.5`, truncated `.`) previously **leaked a raw stdlib `JSON::ParserError`**, breaking the documented contract that `JSON::JSONRepairError` is the only error the gem raises. `parse_number` consumed the leading-dot number and emitted it unchanged (invalid JSON) — a faithful mirror of upstream v3.14.0 — and the 0.7.0 canonical-output re-parse then choked on it.
- `parse_number` now accepts a leading dot (also after a minus sign) and prefixes the missing zero via a new `repair_leading_dot_number` helper: `.5` → `0.5`, `-.5` → `-0.5`, `.5e2` → `50.0`, truncated `.` / `-.` → `0.0` / `-0.0`. This is a deliberate divergence from upstream jsonrepair (which leaves these unrepaired as of v3.14.0, checked against `main` too), matching dirty-json; each divergence site is commented for future sync tractability.
- `repaired_parse` now wraps any stray `JSON::ParserError` in `JSONRepairError`, so even a future repairer bug can't leak the wrong error class.
- Pins `{foo: [}` → `{"foo":[]}` with a spec — a Tier 3 backlog case that already worked.

## Test plan

- [x] New specs for leading-dot numbers, truncated leading-dot numbers, the error-contract guard (stubbed repairer), and the `{foo: [}` pin — watched them fail (leaked `JSON::ParserError`) before the fix
- [x] `bundle exec rake` — RSpec (160 examples, 100% line + branch coverage), RuboCop, `rbs validate`, Steep all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)