### PR TITLE
Repair Markdown list markers like "- {...}" (0.10.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changes
 
+### 2026-06-11 (0.10.0)
+
+* Repair Markdown list markers in front of top-level values:
+  `- {"a": 1}` → `{"a":1}`, and multi-line lists become arrays via the
+  existing newline-delimited JSON handling
+  (`"- {\"a\": 1}\n- {\"b\": 2}"` → `[{"a":1},{"b":2}]`). Bullet
+  markers `-`, `*`, `+` and ordered markers like `1.` / `2)` (up to
+  nine digits, the CommonMark limit) are recognized at the start of
+  the root value and of each newline-delimited line, only when
+  followed by same-line whitespace and a value — so `-5`, a trailing
+  `"- "`, and newline-delimited decimals like `"1.5\n2.5"` keep their
+  number readings, and nothing changes inside nested structures.
+  Previously these inputs raised `JSONRepairError`; two non-raising
+  behaviors change for the better: `"3\n- 5\n7"` now repairs to
+  `[3,5,7]` instead of the corrupt `[3,0,5,7]`, and a single-line
+  `* text` becomes `"text"` instead of `"* text"`. Deliberate
+  divergence from upstream
+  [jsonrepair](https://github.com/josdejong/jsonrepair) (no Markdown
+  list handling as of v3.14.0), and more precise than Python
+  [`json_repair`](https://github.com/mangiucugna/json_repair), which
+  collapses scalar list items to `""`.
+
 ### 2026-06-11 (0.9.0)
 
 * Repair numbers missing the digit before their decimal point:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    json-repair (0.9.0)
+    json-repair (0.10.0)
 
 GEM
   remote: https://rubygems.org/

--- a/README.md
+++ b/README.md
@@ -53,6 +53,18 @@ If you need the parsed Ruby value instead of a string, pass `return_objects: tru
 
 `skip_json_loads: true` skips the stdlib `JSON.parse` attempt and routes the input straight through the repairer. The output is the same; the option is purely a performance knob for callers who know their input will need repair.
 
+### Markdown list markers
+
+LLMs often emit JSON values as items of a Markdown list. Top-level list markers (`-`, `*`, `+`, and ordered markers like `1.` or `2)`) are stripped, and a multi-line list becomes an array:
+
+```ruby
+JSON.repair('- {"a": 1}')                  # => '{"a":1}'
+JSON.repair("- {\"a\": 1}\n- {\"b\": 2}")  # => '[{"a":1},{"b":2}]'
+JSON.repair("1. first\n2. second")         # => '["first","second"]'
+```
+
+A marker only counts when it's followed by whitespace and a value on the same line, so negative numbers like `-5` are unaffected.
+
 ### Reading from a file or IO
 
 `JSON.repair_file(path)` reads a file from disk and repairs its contents. `JSON.repair_io(io)` does the same with any object that responds to `#read` (e.g. `File`, `StringIO`, `$stdin`). Both forward `return_objects:` and `skip_json_loads:` to `JSON.repair`.

--- a/README.md
+++ b/README.md
@@ -31,6 +31,12 @@ puts repaired_json  # Outputs: {"name":"Alice","age":25}
 
 The `repair` method takes a string containing JSON data and returns a corrected version of this string, ensuring it is valid JSON.
 
+Markdown markup in LLM output is handled too: fenced code blocks like `` ```json `` are stripped, and list markers (`-`, `*`, `+`, `1.`) in front of top-level values are removed — a multi-line list becomes an array:
+
+```ruby
+JSON.repair("- {\"a\": 1}\n- {\"b\": 2}")  # => '[{"a":1},{"b":2}]'
+```
+
 Pass `return_objects: true` to get the parsed Ruby value (Hash, Array, or scalar) instead of a string:
 
 ```ruby
@@ -52,18 +58,6 @@ JSON.repair('{"a":1,"a":2}')     # => '{"a":2}'
 If you need the parsed Ruby value instead of a string, pass `return_objects: true` (covered above).
 
 `skip_json_loads: true` skips the stdlib `JSON.parse` attempt and routes the input straight through the repairer. The output is the same; the option is purely a performance knob for callers who know their input will need repair.
-
-### Markdown list markers
-
-LLMs often emit JSON values as items of a Markdown list. Top-level list markers (`-`, `*`, `+`, and ordered markers like `1.` or `2)`) are stripped, and a multi-line list becomes an array:
-
-```ruby
-JSON.repair('- {"a": 1}')                  # => '{"a":1}'
-JSON.repair("- {\"a\": 1}\n- {\"b\": 2}")  # => '[{"a":1},{"b":2}]'
-JSON.repair("1. first\n2. second")         # => '["first","second"]'
-```
-
-A marker only counts when it's followed by whitespace and a value on the same line, so negative numbers like `-5` are unaffected.
 
 ### Reading from a file or IO
 

--- a/lib/json/repair/string_utils.rb
+++ b/lib/json/repair/string_utils.rb
@@ -123,6 +123,10 @@ module JSON
           (char >= EN_QUAD && char <= ZERO_WIDTH_SPACE)
       end
 
+      def same_line_whitespace?(char)
+        whitespace_except_newline?(char) || special_whitespace?(char)
+      end
+
       def quote?(char)
         double_quote_like?(char) || single_quote_like?(char)
       end

--- a/lib/json/repair/version.rb
+++ b/lib/json/repair/version.rb
@@ -2,6 +2,6 @@
 
 module JSON
   module Repair
-    VERSION = '0.9.0'
+    VERSION = '0.10.0'
   end
 end

--- a/lib/json/repairer.rb
+++ b/lib/json/repairer.rb
@@ -38,7 +38,7 @@ module JSON
       parse_markdown_code_block(MARKDOWN_OPEN_BLOCKS)
 
       # repair: skip a Markdown list marker before the root value
-      skip_markdown_list_bullet
+      skip_markdown_list_marker
 
       processed = parse_value
 
@@ -210,7 +210,7 @@ module JSON
 
     # Repair a value behind a Markdown list marker, like "- {"a":1}",
     # by skipping the marker. See markdown_list_marker_length.
-    def skip_markdown_list_bullet
+    def skip_markdown_list_marker
       length = markdown_list_marker_length
       return false unless length
 
@@ -795,7 +795,7 @@ module JSON
 
         # repair: skip a Markdown list marker before the next value
         parse_whitespace_and_skip_comments
-        skip_markdown_list_bullet
+        skip_markdown_list_marker
 
         processed_value = parse_value
       end

--- a/lib/json/repairer.rb
+++ b/lib/json/repairer.rb
@@ -49,7 +49,8 @@ module JSON
       processed_comma = parse_character(COMMA)
       parse_whitespace_and_skip_comments if processed_comma
 
-      if start_of_value?(@json[@index]) && ends_with_comma_or_newline?(@output)
+      if (start_of_value?(@json[@index]) || markdown_list_marker_length) &&
+         ends_with_comma_or_newline?(@output)
         # start of a new value after end of the root level object: looks like
         # newline delimited JSON -> turn into a root level array
         unless processed_comma
@@ -791,6 +792,10 @@ module JSON
             @output = insert_before_last_whitespace(@output, ',')
           end
         end
+
+        # repair: skip a Markdown list marker before the next value
+        parse_whitespace_and_skip_comments
+        skip_markdown_list_bullet
 
         processed_value = parse_value
       end

--- a/lib/json/repairer.rb
+++ b/lib/json/repairer.rb
@@ -38,6 +38,9 @@ module JSON
       parse_markdown_code_block(MARKDOWN_OPEN_BLOCKS)
 
       # repair: skip a Markdown list marker before the root value
+      # (and any comments before it, which parse_value would otherwise
+      # only consume after the marker check has already failed)
+      parse_whitespace_and_skip_comments
       skip_markdown_list_marker
 
       processed = parse_value
@@ -203,7 +206,9 @@ module JSON
       return nil unless same_line_whitespace?(@json[j])
 
       j += 1 while same_line_whitespace?(@json[j])
-      return nil unless start_of_value?(@json[j])
+      # a leading-dot number like ".5" is also a value here: parse_number
+      # repairs it to "0.5" even though start_of_value? does not match it
+      return nil unless start_of_value?(@json[j]) || @json[j] == DOT
 
       marker_length
     end

--- a/lib/json/repairer.rb
+++ b/lib/json/repairer.rb
@@ -37,6 +37,9 @@ module JSON
     def repair
       parse_markdown_code_block(MARKDOWN_OPEN_BLOCKS)
 
+      # repair: skip a Markdown list marker before the root value
+      skip_markdown_list_bullet
+
       processed = parse_value
 
       throw_unexpected_end unless processed
@@ -168,6 +171,50 @@ module JSON
       end
 
       false
+    end
+
+    # Look ahead from @index for a Markdown list marker like "- ", "* ",
+    # "+ ", or "12. " that precedes a value. Returns the marker's length,
+    # or nil when there is no marker. Only consulted at the top level —
+    # the root value and each newline-delimited value — never inside
+    # nested structures. A marker must be followed by same-line
+    # whitespace and a value, so "-5", a trailing "- ", and "-\n{...}"
+    # keep their number readings. Ordered markers are capped at nine
+    # digits (the CommonMark limit) so long truncated decimals are not
+    # mistaken for markers. Divergence from upstream (no Markdown list
+    # handling as of v3.14.0): LLMs frequently emit JSON values as
+    # Markdown list items.
+    def markdown_list_marker_length
+      j = @index
+
+      if [MINUS, ASTERISK, PLUS].include?(@json[j])
+        j += 1
+      elsif digit?(@json[j])
+        j += 1 while digit?(@json[j]) && j - @index < 9
+        return nil unless [DOT, CLOSE_PARENTHESIS].include?(@json[j])
+
+        j += 1
+      else
+        return nil
+      end
+
+      marker_length = j - @index
+      return nil unless same_line_whitespace?(@json[j])
+
+      j += 1 while same_line_whitespace?(@json[j])
+      return nil unless start_of_value?(@json[j])
+
+      marker_length
+    end
+
+    # Repair a value behind a Markdown list marker, like "- {"a":1}",
+    # by skipping the marker. See markdown_list_marker_length.
+    def skip_markdown_list_bullet
+      length = markdown_list_marker_length
+      return false unless length
+
+      @index += length
+      true
     end
 
     # Parse an object like '{"key": "value"}'

--- a/sig/json/repair/string_utils.rbs
+++ b/sig/json/repair/string_utils.rbs
@@ -139,6 +139,8 @@ module JSON
 
       def special_whitespace?: (::String? char) -> bool
 
+      def same_line_whitespace?: (::String? char) -> bool
+
       def quote?: (::String? char) -> bool
 
       def double_quote?: (::String? char) -> bool

--- a/sig/json/repairer.rbs
+++ b/sig/json/repairer.rbs
@@ -47,7 +47,7 @@ module JSON
     # is no marker.
     def markdown_list_marker_length: () -> ::Integer?
 
-    def skip_markdown_list_bullet: () -> bool
+    def skip_markdown_list_marker: () -> bool
 
     # Parse an object like '{"key": "value"}'
     def parse_object: () -> bool

--- a/sig/json/repairer.rbs
+++ b/sig/json/repairer.rbs
@@ -42,6 +42,13 @@ module JSON
 
     def skip_markdown_code_block: (::Array[::String] blocks) -> bool
 
+    # Look ahead for a Markdown list marker like "- " or "12. " that
+    # precedes a value; returns the marker's length, or nil when there
+    # is no marker.
+    def markdown_list_marker_length: () -> ::Integer?
+
+    def skip_markdown_list_bullet: () -> bool
+
     # Parse an object like '{"key": "value"}'
     def parse_object: () -> bool
 

--- a/spec/json_spec.rb
+++ b/spec/json_spec.rb
@@ -691,6 +691,48 @@ RSpec.describe JSON do
       it 'repairs an object with an unquoted key and unclosed array value' do
         expect(JSON.repair('{foo: [}')).to eq('{"foo":[]}')
       end
+
+      it 'repairs a value behind a Markdown list marker' do
+        expect(JSON.repair('- { "k": 1 }')).to eq('{"k":1}')
+        expect(JSON.repair('- [1, 2]')).to eq('[1,2]')
+        expect(JSON.repair('- "text"')).to eq('"text"')
+        expect(JSON.repair('- 5')).to eq('5')
+        expect(JSON.repair('- true')).to eq('true')
+        expect(JSON.repair('- -5')).to eq('-5')
+        expect(JSON.repair('- item one')).to eq('"item one"')
+        # NBSP after the marker counts as same-line whitespace
+        expect(JSON.repair("-\u00A0{\"a\": 1}")).to eq('{"a":1}')
+      end
+
+      it 'repairs a value behind an asterisk or plus Markdown list marker' do
+        expect(JSON.repair('* {"a": 1}')).to eq('{"a":1}')
+        expect(JSON.repair('* 5')).to eq('5')
+        expect(JSON.repair('* item')).to eq('"item"')
+        expect(JSON.repair('+ {"a": 1}')).to eq('{"a":1}')
+      end
+
+      it 'repairs a value behind an ordered Markdown list marker' do
+        expect(JSON.repair('1. {"a": 1}')).to eq('{"a":1}')
+        expect(JSON.repair('2) {"a": 1}')).to eq('{"a":1}')
+        expect(JSON.repair('12. {"a": 1}')).to eq('{"a":1}')
+        expect(JSON.repair('123456789. 5')).to eq('5')
+      end
+
+      it 'repairs a Markdown list marker inside a fenced code block' do
+        expect(JSON.repair("```json\n- {\"a\": 1}\n```")).to eq('{"a":1}')
+      end
+
+      it 'does not mistake numbers or truncated input for Markdown list markers' do
+        expect(JSON.repair('-5')).to eq('-5')
+        expect(JSON.repair('- ')).to eq('0')
+        expect(JSON.repair('* ')).to eq('"*"')
+        expect { JSON.repair('+ ') }.to raise_error(JSON::JSONRepairError)
+        expect(JSON.repair('1.')).to eq('1.0')
+        expect(JSON.repair("-\n{\"a\": 1}")).to eq('[0,{"a":1}]')
+        expect(JSON.repair('[- 1, 2]')).to eq('[0,1,2]')
+        expect { JSON.repair('1234567890. 5') }.to raise_error(JSON::JSONRepairError)
+        expect { JSON.repair('- - 5') }.to raise_error(JSON::JSONRepairError)
+      end
     end
 
     context 'when the JSON cannot be repaired' do

--- a/spec/json_spec.rb
+++ b/spec/json_spec.rb
@@ -733,6 +733,28 @@ RSpec.describe JSON do
         expect { JSON.repair('1234567890. 5') }.to raise_error(JSON::JSONRepairError)
         expect { JSON.repair('- - 5') }.to raise_error(JSON::JSONRepairError)
       end
+
+      it 'repairs a multi-line Markdown list into an array' do
+        expect(JSON.repair("- {\"a\": 1}\n- {\"b\": 2}")).to eq('[{"a":1},{"b":2}]')
+        expect(JSON.repair("* {\"a\": 1}\n* {\"b\": 2}")).to eq('[{"a":1},{"b":2}]')
+        expect(JSON.repair("1. {\"a\": 1}\n2. {\"b\": 2}")).to eq('[{"a":1},{"b":2}]')
+        expect(JSON.repair("- item one\n- item two")).to eq('["item one","item two"]')
+        expect(JSON.repair("1. first\n2. second")).to eq('["first","second"]')
+        expect(JSON.repair("- {\"a\": 1},\n- {\"b\": 2}")).to eq('[{"a":1},{"b":2}]')
+        expect(JSON.repair("1) {\"a\": 1}\n2) {\"b\": 2}")).to eq('[{"a":1},{"b":2}]')
+        expect(JSON.repair("+ 1\n+ 2")).to eq('[1,2]')
+      end
+
+      it 'repairs newline delimited JSON with Markdown list markers on some lines' do
+        expect(JSON.repair("{\"a\": 1}\n* {\"b\": 2}")).to eq('[{"a":1},{"b":2}]')
+        expect(JSON.repair("3\n- 5\n7")).to eq('[3,5,7]')
+        expect(JSON.repair("1\n- 2,\n- 3")).to eq('[1,2,3]')
+      end
+
+      it 'keeps newline delimited decimals and concatenated strings intact' do
+        expect(JSON.repair("1.5\n2.5")).to eq('[1.5,2.5]')
+        expect(JSON.repair("\"a\"\n+ \"b\"")).to eq('"ab"')
+      end
     end
 
     context 'when the JSON cannot be repaired' do

--- a/spec/json_spec.rb
+++ b/spec/json_spec.rb
@@ -700,8 +700,14 @@ RSpec.describe JSON do
         expect(JSON.repair('- true')).to eq('true')
         expect(JSON.repair('- -5')).to eq('-5')
         expect(JSON.repair('- item one')).to eq('"item one"')
+        expect(JSON.repair('- .5')).to eq('0.5')
         # NBSP after the marker counts as same-line whitespace
         expect(JSON.repair("-\u00A0{\"a\": 1}")).to eq('{"a":1}')
+      end
+
+      it 'repairs a Markdown list marker after a leading comment' do
+        expect(JSON.repair("/* c */\n- {\"a\": 1}")).to eq('{"a":1}')
+        expect(JSON.repair("// note\n- 1\n- 2")).to eq('[1,2]')
       end
 
       it 'repairs a value behind an asterisk or plus Markdown list marker' do
@@ -743,6 +749,7 @@ RSpec.describe JSON do
         expect(JSON.repair("- {\"a\": 1},\n- {\"b\": 2}")).to eq('[{"a":1},{"b":2}]')
         expect(JSON.repair("1) {\"a\": 1}\n2) {\"b\": 2}")).to eq('[{"a":1},{"b":2}]')
         expect(JSON.repair("+ 1\n+ 2")).to eq('[1,2]')
+        expect(JSON.repair("- .5\n- .25")).to eq('[0.5,0.25]')
       end
 
       it 'repairs newline delimited JSON with Markdown list markers on some lines' do


### PR DESCRIPTION
## Summary
- Markdown list markers (`-`, `*`, `+`, and ordered `1.` / `2)` up to nine digits, the CommonMark cap) in front of top-level values are now stripped: `- {"a": 1}` repairs to `{"a":1}` instead of raising `JSONRepairError`.
- Multi-line lists become arrays via the existing NDJSON handling: `- {"a": 1}\n- {"b": 2}` → `[{"a":1},{"b":2}]`, including scalar items (`- item one\n- item two` → `["item one","item two"]`) where Python's json_repair collapses to a lossy `""`.
- A marker only counts when followed by same-line whitespace and a value, so `-5`, a trailing `- `, `1.`, and NDJSON decimals like `1.5\n2.5` keep their number readings, and nothing changes inside nested structures (`[- 1, 2]` stays `[0,1,2]`).
- Two non-raising behaviors change for the better (both pinned in specs): `3\n- 5\n7` → `[3,5,7]` instead of the corrupt `[3,0,5,7]`, and single-line `* text` → `"text"` instead of `"* text"`.
- Deliberate divergence from upstream jsonrepair (no Markdown list handling as of v3.14.0), commented at each site per the 0.9.0 leading-dot precedent. New `markdown_list_marker_length` lookahead + `skip_markdown_list_marker` in `Repairer`, `same_line_whitespace?` in `StringUtils`, RBS in lockstep.

## Test Plan
- [x] TDD: new examples failed first, then passed (`spec/json_spec.rb`, 8 new examples incl. guard pins)
- [x] `bundle exec rake` green: RSpec 168 examples / 0 failures with 100% line+branch coverage, RuboCop clean, `rbs validate` clean, Steep clean
- [x] README/CHANGELOG examples verified against the library

🤖 Generated with [Claude Code](https://claude.com/claude-code)