### PR TITLE
Repair doubled-colon object values like {"a": "b": "c"} (0.11.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changes
 
+### 2026-06-12 (0.11.0)
+
+* Repair object string values with unescaped quotes around a colon
+  ("doubled colon"): `{"a": "b": "c"}` → `{"a":"b\": \"c"}` — the
+  value reads as `b": "c`, the unescaped-quotes interpretation. The
+  merge preserves the literal characters between the strings
+  (whitespace, original quote style) and repeats greedily
+  (`{"a": "b": "c": "d"}` → value `b": "c": "d`). Only the
+  string–colon–string shape is repaired: non-string shapes like
+  `{"a": "b": 1}` or `{"a": 1: 2}` still raise `JSONRepairError`
+  rather than silently dropping data (Python `json_repair` drops the
+  `: 1` there). Previously all of these raised "Object key expected".
+  Deliberate divergence from upstream
+  [jsonrepair](https://github.com/josdejong/jsonrepair) (raises as of
+  v3.14.0), matching
+  [Go json-repair](https://github.com/RealAlexandreAI/json-repair)
+  and Python
+  [`json_repair`](https://github.com/mangiucugna/json_repair) on the
+  canonical case.
+
 ### 2026-06-11 (0.10.0)
 
 * Repair Markdown list markers in front of top-level values:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    json-repair (0.10.0)
+    json-repair (0.11.0)
 
 GEM
   remote: https://rubygems.org/

--- a/README.md
+++ b/README.md
@@ -37,6 +37,12 @@ Markdown markup in LLM output is handled too: fenced code blocks like `` ```json
 JSON.repair("- {\"a\": 1}\n- {\"b\": 2}")  # => '[{"a":1},{"b":2}]'
 ```
 
+Object values containing unescaped quotes around a colon are merged back into a single string value:
+
+```ruby
+JSON.repair('{"a": "b": "c"}')  # => '{"a":"b\": \"c"}' — the value reads as 'b": "c'
+```
+
 Pass `return_objects: true` to get the parsed Ruby value (Hash, Array, or scalar) instead of a string:
 
 ```ruby

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is a Ruby gem designed to repair broken JSON strings. Inspired by and based
 
 ## Installation
 
-Add this gem to your application's Gemfield by executing:
+Add this gem to your application's Gemfile by executing:
 
 ```bash
 $ bundle add json-repair

--- a/lib/json/repair/string_utils.rb
+++ b/lib/json/repair/string_utils.rb
@@ -127,6 +127,10 @@ module JSON
         whitespace_except_newline?(char) || special_whitespace?(char)
       end
 
+      def whitespace_or_special?(char)
+        whitespace?(char) || special_whitespace?(char)
+      end
+
       def quote?(char)
         double_quote_like?(char) || single_quote_like?(char)
       end

--- a/lib/json/repair/version.rb
+++ b/lib/json/repair/version.rb
@@ -2,6 +2,6 @@
 
 module JSON
   module Repair
-    VERSION = '0.10.0'
+    VERSION = '0.11.0'
   end
 end

--- a/lib/json/repairer.rb
+++ b/lib/json/repairer.rb
@@ -294,6 +294,10 @@ module JSON
           end
           # :nocov:
         end
+
+        # repair: an object string value with unescaped quotes around a
+        # colon, like {"a": "b": "c"}
+        repair_doubled_colon if processed_value
       end
 
       if @json[@index] == CLOSING_BRACE
@@ -305,6 +309,59 @@ module JSON
       end
 
       true
+    end
+
+    # Repair an object value with unescaped quotes around a colon, like
+    # {"a": "b": "c"}, by merging it all into one string value: 'b": "c'
+    # (the unescaped-quotes reading of the input). Greedy: keeps merging
+    # while another `: "..."` follows. Only the string-colon-string
+    # shape is repaired; anything else falls through to the regular
+    # error paths. Divergence from upstream (which raises "Object key
+    # expected" as of v3.14.0), matching the Go and Python json-repair
+    # libraries on the canonical case.
+    def repair_doubled_colon
+      loop do
+        colon = @index
+        # :nocov: kept for symmetry with the start_quote scan below; unreachable
+        # because @index never rests on whitespace here. On first entry,
+        # parse_value ends with parse_whitespace_and_skip_comments. On greedy
+        # re-entry, every parse_string exit leaves @index off-whitespace: the
+        # EOF path (nil is not whitespace), the stop_at_index path (a
+        # prev_non_whitespace_index position), and the end-quote path (ends in
+        # parse_concatenated_string, whose leading whitespace skip consumes
+        # newlines too). If a future parse_value/parse_string change breaks
+        # that, this scan becomes live and the :nocov: will hide it.
+        colon += 1 while whitespace_or_special?(@json[colon])
+        # :nocov:
+        return unless @json[colon] == COLON
+
+        # scan past special whitespace too (unlike prev_non_whitespace_index):
+        # parse_whitespace treats NBSP and friends as whitespace, so this
+        # repair should as well. The value's last character (at worst the
+        # object's opening brace) always stops the scan before index 0.
+        end_quote = colon - 1
+        end_quote -= 1 while whitespace_or_special?(@json[end_quote])
+        return unless quote?(@json[end_quote])
+
+        start_quote = colon + 1
+        start_quote += 1 while whitespace_or_special?(@json[start_quote])
+        return unless quote?(@json[start_quote])
+
+        # repair: replace the end quote already emitted (plus any copied
+        # trailing whitespace) with the literal input span from that end
+        # quote through the next start quote, escaped as string content
+        @output = strip_last_occurrence(@output, '"', strip_remaining_text: true)
+        @json[end_quote..start_quote].each_char do |char|
+          @output << (char == DOUBLE_QUOTE ? '\"' : CONTROL_CHARACTERS.fetch(char, char))
+        end
+
+        # let parse_string consume the rest of the merged string, then
+        # drop the start quote it emits (already emitted escaped above)
+        @index = start_quote
+        start = @output.length
+        parse_string
+        @output = remove_at_index(@output, start, 1)
+      end
     end
 
     def skip_character(char)

--- a/sig/json/repair/string_utils.rbs
+++ b/sig/json/repair/string_utils.rbs
@@ -141,6 +141,8 @@ module JSON
 
       def same_line_whitespace?: (::String? char) -> bool
 
+      def whitespace_or_special?: (::String? char) -> bool
+
       def quote?: (::String? char) -> bool
 
       def double_quote?: (::String? char) -> bool

--- a/sig/json/repairer.rbs
+++ b/sig/json/repairer.rbs
@@ -52,6 +52,10 @@ module JSON
     # Parse an object like '{"key": "value"}'
     def parse_object: () -> bool
 
+    # Repair an object value with unescaped quotes around a colon,
+    # like {"a": "b": "c"}, by merging it into one string value.
+    def repair_doubled_colon: () -> void
+
     def skip_character: (::String char) -> bool
 
     # Skip ellipsis like "[1,2,3,...]" or "[1,2,3,...,9]" or "[...,7,8,9]"

--- a/spec/json_spec.rb
+++ b/spec/json_spec.rb
@@ -762,6 +762,40 @@ RSpec.describe JSON do
         expect(JSON.repair("1.5\n2.5")).to eq('[1.5,2.5]')
         expect(JSON.repair("\"a\"\n+ \"b\"")).to eq('"ab"')
       end
+
+      it 'repairs an object string value with unescaped quotes around a colon' do
+        expect(JSON.repair('{"a": "b": "c"}')).to eq('{"a":"b\": \"c"}')
+        expect(JSON.repair('{"a": "b":"c"}')).to eq('{"a":"b\":\"c"}')
+        expect(JSON.repair('{"a": "b": "c", "d": "e"}')).to eq('{"a":"b\": \"c","d":"e"}')
+        expect(JSON.repair('{"a": "b" : "c"}')).to eq('{"a":"b\" : \"c"}')
+        expect(JSON.repair(%q({"a": 'b': 'c'}))).to eq(%q({"a":"b': 'c"}))
+        expect(JSON.repair('[{"a": "b": "c"}]')).to eq('[{"a":"b\": \"c"}]')
+        expect(JSON.repair('{"a": "b": "c"}', return_objects: true)).to eq({ 'a' => 'b": "c' })
+        expect(JSON.repair('{"a": b": "c"}')).to eq('{"a":"b\": \"c"}')
+      end
+
+      it 'repairs repeated doubled colons greedily' do
+        expect(JSON.repair('{"a": "b": "c": "d"}')).to eq('{"a":"b\": \"c\": \"d"}')
+        expect(JSON.repair('{"a": "b": "c, x": "d"}')).to eq('{"a":"b\": \"c, x\": \"d"}')
+      end
+
+      it 'repairs a doubled colon in truncated or comma-less objects' do
+        expect(JSON.repair('{"a": "b": "c"')).to eq('{"a":"b\": \"c"}')
+        expect(JSON.repair('{"a": "b": "c" "d": "e"}')).to eq('{"a":"b\": \"c","d":"e"}')
+      end
+
+      it 'preserves the literal span when merging a doubled colon' do
+        expect(JSON.repair(%({"a": "b"\n: "c"}))).to eq('{"a":"b\"\n: \"c"}')
+        expect(JSON.repair('{"a": "b\"": "c"}')).to eq('{"a":"b\"\": \"c"}')
+        expect(JSON.repair('{"a": "b\"": "c"}', return_objects: true)).to eq({ 'a' => 'b"": "c' })
+        expect(JSON.repair('{"a": “b”: “c”}')).to eq('{"a":"b”: “c"}')
+      end
+
+      it 'repairs a doubled colon across special whitespace' do
+        expect(JSON.repair("{\"a\": \"b\"\u00A0: \"c\"}")).to eq("{\"a\":\"b\\\"\u00A0: \\\"c\"}")
+        expect(JSON.repair("{\"a\": \"b\":\u00A0\"c\"}")).to eq("{\"a\":\"b\\\":\u00A0\\\"c\"}")
+        expect(JSON.repair('{"a": "b":　"c"}')).to eq('{"a":"b\":　\"c"}')
+      end
     end
 
     context 'when the JSON cannot be repaired' do
@@ -818,6 +852,63 @@ RSpec.describe JSON do
       specify do
         expect { JSON.repair("\"abc\u001F\"") }.to \
           raise_error(JSON::JSONRepairError, /\AInvalid character "\\u001f" at index 4\z/i)
+      end
+
+      # Guard branches in repair_doubled_colon: colon found, but the char
+      # before it is not a quote (non-string value), or the char after the
+      # colon is not a quote (non-string after colon).
+      specify do
+        expect { JSON.repair('{"a": 1: "c"}') }.to \
+          raise_error(JSON::JSONRepairError, 'Object key expected at index 7')
+      end
+
+      specify do
+        expect { JSON.repair('{"a": "b":1}') }.to \
+          raise_error(JSON::JSONRepairError, 'Object key expected at index 9')
+      end
+
+      # doubled-colon guards: only the string-colon-string shape is
+      # repaired (see repair_doubled_colon); these must keep raising
+      specify do
+        expect { JSON.repair('{"a": "b": 1}') }.to \
+          raise_error(JSON::JSONRepairError, 'Object key expected at index 9')
+      end
+
+      specify do
+        expect { JSON.repair('{"a": "b": true}') }.to \
+          raise_error(JSON::JSONRepairError, 'Object key expected at index 9')
+      end
+
+      specify do
+        expect { JSON.repair('{"a": 1: 2}') }.to \
+          raise_error(JSON::JSONRepairError, 'Object key expected at index 7')
+      end
+
+      specify do
+        expect { JSON.repair('{"a": {"x":"y"}: "c"}') }.to \
+          raise_error(JSON::JSONRepairError, 'Object key expected at index 15')
+      end
+
+      specify do
+        expect { JSON.repair('{"a": "b":}') }.to \
+          raise_error(JSON::JSONRepairError, 'Object key expected at index 9')
+      end
+
+      specify do
+        expect { JSON.repair('{"a": "b" /* note */ : "c"}') }.to \
+          raise_error(JSON::JSONRepairError, 'Object key expected at index 21')
+      end
+
+      specify do
+        expect { JSON.repair('{"a": b: "c"}') }.to \
+          raise_error(JSON::JSONRepairError, 'Colon expected at index 12')
+      end
+
+      specify do
+        # greedy merge engages, then bails at the non-string tail; the
+        # raise discards all partial output
+        expect { JSON.repair('{"x": "a": "b": 5}') }.to \
+          raise_error(JSON::JSONRepairError, 'Object key expected at index 14')
       end
 
       describe '#position on the raised error' do


### PR DESCRIPTION
## Summary

- Repairs object string values with unescaped quotes around a colon: `{"a": "b": "c"}` → `{"a":"b\": \"c"}` — the value reads as `b": "c`, the unescaped-quotes interpretation. New private `repair_doubled_colon` in `lib/json/repairer.rb`, hooked into `parse_object` after each parsed value.
- The merge preserves the literal span between the strings (whitespace, original quote style — single/smart quotes stay literal) and repeats greedily (`{"a": "b": "c": "d"}` → value `b": "c": "d`).
- Only the string–colon–string shape is repaired. Non-string shapes (`{"a": "b": 1}`, `{"a": 1: 2}`, `{"a": {…}: "c"}`, dangling `{"a": "b":}`) keep raising `JSONRepairError` — no silent data loss (Python `json_repair` drops the trailing `: 1` there). Eight guard specs pin the raises with exact messages and positions.
- Deliberate divergence from upstream [jsonrepair](https://github.com/josdejong/jsonrepair) (raises "Object key expected" as of v3.14.0), matching [Go json-repair](https://github.com/RealAlexandreAI/json-repair) and Python [`json_repair`](https://github.com/mangiucugna/json_repair) on the canonical case; commented at the divergence site per project convention.
- RBS signature in lockstep; CHANGELOG + README for 0.11.0; rides along a one-word README typo fix (Gemfield → Gemfile).

## Test Plan

- [x] `bundle exec rake` — 183 examples, 0 failures; SimpleCov 100.0% line (639/639) and branch (261/261); RuboCop clean; `rbs validate` + `steep check` clean
- [x] New spec groups: repairs (canonical, greedy, truncated, comma-less, literal-span/smart-quote, `return_objects`) and keep-raising guards
- [x] `bundle exec rake bench` before/after — all scenarios within run-to-run noise (±1.5% vs ±7–8% error bars)
- [x] Differential check vs `main` on non-matching inputs — byte-identical outputs (the repair mutates no state until the full shape is confirmed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)