### PR TITLE
Fix TypeError on string input ending in a lone backslash (0.11.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changes
 
+### 2026-06-12 (0.11.1)
+
+* Fix a `TypeError` crash on input ending in a lone backslash inside a
+  string: `"abc\` now repairs to `"abc"` (likewise `"\` → `""`,
+  `["abc\` → `["abc"]`, `{"a": "b\` → `{"a":"b"}`), matching upstream
+  [jsonrepair](https://github.com/josdejong/jsonrepair) v3.14.0. This
+  was a porting bug — JS `charAt` past EOF returns `''` where Ruby
+  `String#[]` returns `nil`, so the invalid-escape repair in
+  `parse_string` crashed on `str << nil` instead of ending the string,
+  violating the contract that `JSONRepairError` is the only error
+  raised. Found by differential fuzzing during the 0.11.0 review.
+
 ### 2026-06-12 (0.11.0)
 
 * Repair object string values with unescaped quotes around a colon

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    json-repair (0.11.0)
+    json-repair (0.11.1)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/json/repair/version.rb
+++ b/lib/json/repair/version.rb
@@ -2,6 +2,6 @@
 
 module JSON
   module Repair
-    VERSION = '0.11.0'
+    VERSION = '0.11.1'
   end
 end

--- a/lib/json/repairer.rb
+++ b/lib/json/repairer.rb
@@ -530,7 +530,9 @@ module JSON
           return true
         elsif @json[@index] == BACKSLASH
           # handle escaped content like \n or ★
-          char = @json[@index + 1]
+          # nil at EOF: '' mirrors JS charAt, making the invalid-escape
+          # repair below a no-op that ends the string
+          char = @json[@index + 1] || ''
           escape_char = ESCAPE_CHARACTERS[char]
           if escape_char
             str << @json[@index, 2]

--- a/spec/json_spec.rb
+++ b/spec/json_spec.rb
@@ -193,6 +193,13 @@ RSpec.describe JSON do
           eq("{\"message\":\"with, multiple, commma's, you see?\"}")
       end
 
+      it 'repairs a string truncated at a lone backslash' do
+        expect(JSON.repair('"abc\\')).to eq('"abc"')
+        expect(JSON.repair('"\\')).to eq('""')
+        expect(JSON.repair('["abc\\')).to eq('["abc"]')
+        expect(JSON.repair('{"a": "b\\')).to eq('{"a":"b"}')
+      end
+
       it 'repairs ellipsis in an array' do
         expect(JSON.repair('[1,2,3,...]')).to eq('[1,2,3]')
         expect(JSON.repair('[1, 2, 3, ... ]')).to eq('[1,2,3]')


### PR DESCRIPTION
## Summary

- Fixes a `TypeError` crash (`str << nil`) on input ending in a lone backslash inside a string — e.g. `"abc\` — which violated the contract that `JSONRepairError` is the only error `JSON.repair` raises. Pre-existing bug found by differential fuzzing during the 0.11.0 review.
- Root cause is a JS→Ruby porting mismatch: upstream's `text.charAt(i + 1)` returns `''` past EOF, where Ruby's `@json[@index + 1]` returns `nil`. The one-line fix (`char = @json[@index + 1] || ''`) mirrors the JS semantics, so the invalid-escape repair becomes a no-op at EOF and the existing missing-end-quote repair closes the string. Control flow stays line-for-line aligned with upstream for future syncs.
- Output now matches upstream jsonrepair v3.14.0 exactly (verified against the npm package): `"abc\` → `"abc"`, `"\` → `""`, `["abc\` → `["abc"]`, `{"a": "b\` → `{"a":"b"}`. Upstream pins this input family in `src/index.test.ts:414`.

## Test Plan

- [x] New spec `repairs a string truncated at a lone backslash` (4 assertions) — watched it fail with the exact `TypeError` before the fix, pass after
- [x] `bundle exec rake` exits 0: 185 examples / 0 failures, 100% line + branch coverage, RuboCop clean, RBS valid, Steep clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)