### PR TITLE
Fix doubled-colon repair mangling pairs separated by stray junk words (0.11.2)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,15 @@
+# Merge our Exclude lists with RuboCop's defaults (vendor/**/*, tmp/**/*, …)
+# instead of replacing them — CI vendors gems into vendor/bundle, which
+# RuboCop must keep skipping.
+inherit_mode:
+  merge:
+    - Exclude
+
 AllCops:
   TargetRubyVersion: 3.0
+  Exclude:
+    # gitignored local planning notes and scratch tooling (see CLAUDE.md)
+    - docs/**/*
 
 Style/Documentation:
   Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,26 @@
 # Changes
 
-### 2026-06-12 (0.11.1)
+### 2026-06-12 (0.11.2)
+
+* Fix the 0.11.0 doubled-colon repair silently mangling objects with a
+  stray junk word between pairs. `{"value_1": true, COMMENT "value_2":
+  "data"}` returned `{"value_1":true,"COMMENT":"value_2\": \"data"}`
+  (the junk word became a key and swallowed the real pair), and
+  `{ "key": "value" COMMENT "key2": "value2" }` returned a single
+  glued string value. Both shapes now raise "Object key expected"
+  again at the same positions as upstream
+  [jsonrepair](https://github.com/josdejong/jsonrepair) v3.14.0,
+  restoring the pre-0.11.0 behavior: the merge is skipped when the
+  pair already needed a missing-colon repair or the value string was
+  itself salvaged by the unescaped-quote repair — signals that the
+  pair was malformed in a way the merge would compound, not fix. The
+  salvage signal survives string concatenation: in
+  `{"a": "b" x "c" + "d": "e"}` the `+ "d"` segment no longer clears
+  it (caught in review by Copilot). All
+  0.11.0 repairs (canonical, greedy, escaped quotes, unquoted
+  keys/values) are unchanged. Go and Python `json_repair` instead
+  drop the junk word; we deliberately keep raising rather than
+  silently discarding input (see the 0.11.0 note).
 
 * Fix a `TypeError` crash on input ending in a lone backslash inside a
   string: `"abc\` now repairs to `"abc"` (likewise `"\` → `""`,

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    json-repair (0.11.1)
+    json-repair (0.11.2)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/json/repair/version.rb
+++ b/lib/json/repair/version.rb
@@ -2,6 +2,6 @@
 
 module JSON
   module Repair
-    VERSION = '0.11.1'
+    VERSION = '0.11.2'
   end
 end

--- a/lib/json/repairer.rb
+++ b/lib/json/repairer.rb
@@ -32,6 +32,7 @@ module JSON
       @json = json
       @index = 0
       @output = +''
+      @repaired_unescaped_quote = false
     end
 
     def repair
@@ -295,8 +296,14 @@ module JSON
         end
 
         # repair: an object string value with unescaped quotes around a
-        # colon, like {"a": "b": "c"}
-        repair_doubled_colon if processed_value
+        # colon, like {"a": "b": "c"}. Skipped when this pair already
+        # needed a repair that makes the merge compound garbage: a
+        # missing colon (the "key" was a stray junk word, like
+        # {"v1": true, COMMENT "v2": "data"}) or a value glued together
+        # by the unescaped-quote repair (like
+        # {"k": "v" COMMENT "k2": "v2"}); both keep raising, matching
+        # upstream
+        repair_doubled_colon if processed_value && processed_colon && !@repaired_unescaped_quote
       end
 
       if @json[@index] == CLOSING_BRACE
@@ -315,9 +322,13 @@ module JSON
     # (the unescaped-quotes reading of the input). Greedy: keeps merging
     # while another `: "..."` follows. Only the string-colon-string
     # shape is repaired; anything else falls through to the regular
-    # error paths. Divergence from upstream (which raises "Object key
-    # expected" as of v3.14.0), matching the Go and Python json-repair
-    # libraries on the canonical case.
+    # error paths. The call site additionally requires the pair's colon
+    # to be present in the input and the value string to have parsed
+    # without the unescaped-quote repair (@repaired_unescaped_quote) —
+    # when either repair already fired, the pair was malformed in a way
+    # this merge would compound, not fix. Divergence from upstream
+    # (which raises "Object key expected" as of v3.14.0), matching the
+    # Go and Python json-repair libraries on the canonical case.
     def repair_doubled_colon
       loop do
         colon = @index
@@ -399,6 +410,9 @@ module JSON
     #   and fixing the string by inserting a quote there, or stopping at a
     #   stop index detected in the first iteration.
     def parse_string(stop_at_delimiter: false, stop_at_index: -1)
+      # fresh parse (the backtracking re-invocations below rebuild the
+      # string from scratch, so they reset too); see repair_doubled_colon
+      @repaired_unescaped_quote = false
       skip_escape_chars = @json[@index] == BACKSLASH
       if skip_escape_chars
         # repair: remove the first escape character
@@ -508,6 +522,7 @@ module JSON
 
           # repair unescaped quote
           str = "#{str[...o_quote]}\\#{str[o_quote..]}"
+          @repaired_unescaped_quote = true
         elsif stop_at_delimiter && unquoted_string_delimiter?(@json[@index])
           # we're in the mode to stop the string at the first delimiter
           # because there is an end quote missing
@@ -807,7 +822,12 @@ module JSON
         # repair: remove the end quote of the first string
         @output = strip_last_occurrence(@output, '"', strip_remaining_text: true)
         start = @output.length
+        # the segments form one logical string value: keep the doubled-colon
+        # guard's flag set when an earlier segment needed the unescaped-quote
+        # repair (parse_string resets it on entry)
+        repaired_earlier_segment = @repaired_unescaped_quote
         parsed_str = parse_string
+        @repaired_unescaped_quote ||= repaired_earlier_segment
         @output = if parsed_str
                     # repair: remove the start quote of the second string
                     remove_at_index(@output, start, 1)

--- a/sig/json/repairer.rbs
+++ b/sig/json/repairer.rbs
@@ -15,6 +15,8 @@ module JSON
 
     @output: ::String
 
+    @repaired_unescaped_quote: bool
+
     include Repair::StringUtils
 
     CONTROL_CHARACTERS: ::Hash[::String, "\\b" | "\\f" | "\\n" | "\\r" | "\\t"]

--- a/spec/json_spec.rb
+++ b/spec/json_spec.rb
@@ -906,6 +906,30 @@ RSpec.describe JSON do
           raise_error(JSON::JSONRepairError, 'Object key expected at index 21')
       end
 
+      # doubled-colon guard: when the value string was itself salvaged by the
+      # unescaped-quote repair (a stray word between two quoted strings glued
+      # the spans together), merging across the following colon would compound
+      # the damage into silent garbage — keep raising like upstream
+      specify do
+        expect { JSON.repair('{ "key": "value" COMMENT "key2": "value2" }') }.to \
+          raise_error(JSON::JSONRepairError, 'Object key expected at index 31')
+      end
+
+      # the guard survives string concatenation: the salvaged first segment
+      # keeps the flag set even though `+ "..."` segments re-enter parse_string
+      specify do
+        expect { JSON.repair('{"a": "b" x "c" + "d": "e"}') }.to \
+          raise_error(JSON::JSONRepairError, 'Object key expected at index 21')
+      end
+
+      # stray junk word between object pairs: Go/Python json-repair silently
+      # drop the word; upstream JS raises — we keep parity (see CHANGELOG.md,
+      # 0.11.2)
+      specify do
+        expect { JSON.repair('{"value_1": true, COMMENT "value_2": "data"}') }.to \
+          raise_error(JSON::JSONRepairError, 'Object key expected at index 35')
+      end
+
       specify do
         expect { JSON.repair('{"a": b: "c"}') }.to \
           raise_error(JSON::JSONRepairError, 'Colon expected at index 12')


### PR DESCRIPTION
## Summary

The 0.11.0 doubled-colon merge fired after other repairs had already signaled the pair was malformed, compounding them into silent garbage:

- `{"value_1": true, COMMENT "value_2": "data"}` → `{"value_1":true,"COMMENT":"value_2\": \"data"}` — the junk word became an unquoted key via the missing-colon repair, and the merge then swallowed the real pair into its value.
- `{ "key": "value" COMMENT "key2": "value2" }` → `{"key":"value\" COMMENT \"key2\": \"value2"}` — the unescaped-quote repair glued the spans into one string and the merge appended the next value to it.

Both raised `Object key expected` before 0.11.0, matching upstream jsonrepair v3.14.0 exactly; they now raise again at upstream-identical positions. The merge is skipped when the pair's colon was missing from the input (`processed_colon`) or the value string was salvaged by the unescaped-quote repair (new `@repaired_unescaped_quote` flag, reset at every `parse_string` entry). All 0.11.0 repairs (canonical, greedy, escaped quotes, unquoted keys/values) are unchanged.

Stray junk words between pairs stay deliberately unrepaired: Go/Python json-repair silently drop them (Python's own log message calls it "an extreme corner case in which the LLM added a comment"), upstream raises — we keep upstream parity rather than silently discarding input, pinned with adversarial specs.

## Validation

- Differential fuzz vs upstream jsonrepair@3.14.0 over 4,075 inputs (hand-crafted junk-word/colon/quote grid + seeded mutations): the guard eliminates 223 silent-mangle outputs, introduces zero new repairs and zero new raises vs main; remaining diffs are documented divergences. The fuzz also surfaced two pre-existing upstream-shared bugs (infinite recursion on `"y"\, "z"`; invalid-JSON emissions like `[e0]`/`-05`), logged in the local backlog — not addressed here.
- `bundle exec rake` green: 187 examples, 0 failures, 100% line + branch coverage, RuboCop, RBS, Steep.
- `rake bench` flat vs main (all four scenarios within error bars).

## Test Plan

- [x] New specs: both compounding shapes raise `Object key expected` at upstream-identical positions (31, 35)
- [x] Adversarial pin: canonical junk-word case keeps raising (parity decision)
- [x] All pinned 0.11.0 doubled-colon repairs unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)