### PR TITLE
Fix infinite recursion on a string followed by an escaped delimiter (0.11.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changes
 
+### 2026-06-12 (0.11.3)
+
+* Fix infinite recursion (`SystemStackError`) on a quoted string
+  followed by a backslash-escaped delimiter, like `["y"\, "z"]`. The
+  missing-end-quote retry in `parse_string` stops at the comma it
+  detected in the first pass, but the invalid-escape repair consumed
+  `\,` as one two-character step, jumping over the stop index and
+  re-firing the retry with identical arguments forever — violating the
+  contract that `JSONRepairError` is the only error raised. The escaped
+  delimiter now ends the string there and the dangling backslash is
+  dropped (the standard invalid-escape repair): `["y"\, "z"]` →
+  `["y\"","z"]`. The stop-index check is also hardened from `==` to
+  `>=` so no future multi-character advance can step over it and
+  recurse. Deliberate divergence from upstream
+  [jsonrepair](https://github.com/josdejong/jsonrepair), which crashes
+  with "Maximum call stack size exceeded" on the same input as of
+  v3.14.0 (still its latest release). Found by differential fuzzing
+  during the 0.11.2 work and re-validated the same way: across a
+  240-input grid of escape-adjacent shapes, only previously-crashing
+  inputs changed behavior — object shapes like `{"k": "y"\, "z"}` now
+  raise the same "Colon expected" as their backslash-free analog
+  `{"k": "y", "z"}`. Benchmarks flat vs 0.11.2.
+
 ### 2026-06-12 (0.11.2)
 
 * Fix the 0.11.0 doubled-colon repair silently mangling objects with a

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    json-repair (0.11.2)
+    json-repair (0.11.3)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/json/repair/version.rb
+++ b/lib/json/repair/version.rb
@@ -2,6 +2,6 @@
 
 module JSON
   module Repair
-    VERSION = '0.11.2'
+    VERSION = '0.11.3'
   end
 end

--- a/lib/json/repairer.rb
+++ b/lib/json/repairer.rb
@@ -463,7 +463,13 @@ module JSON
           return true
         end
 
-        if @index == stop_at_index
+        # >= with a sentinel guard, not ==. Divergence from upstream (which
+        # compares with == as of v3.14.0): a multi-character advance below
+        # can step over the stop index, and resuming the comma-path retry
+        # from beyond it would re-fire that retry with identical arguments
+        # forever. The invalid-escape repair below avoids the only known
+        # overshoot; this is the backstop guaranteeing termination.
+        if stop_at_index >= 0 && @index >= stop_at_index
           # use the stop index detected in the first iteration, and repair end quote
           str = insert_before_last_whitespace(str, '"')
           @output << str
@@ -569,6 +575,15 @@ module JSON
             # repair a backslash escaped newline (like in Bash scripts)
             str << '\n'
             @index += 2
+          elsif @index + 1 == stop_at_index
+            # repair invalid escape character: remove it — but the escaped
+            # character is the delimiter the comma-path retry said to stop
+            # at, so drop only the backslash and let the stop check above
+            # fire there, keeping the delimiter a delimiter. Divergence
+            # from upstream, which consumes both characters, jumps the stop
+            # index, and crashes ("Maximum call stack size exceeded" on
+            # inputs like `["y"\, "z"]` as of v3.14.0).
+            @index += 1
           else
             # repair invalid escape character: remove it
             str << char

--- a/spec/json_spec.rb
+++ b/spec/json_spec.rb
@@ -200,6 +200,12 @@ RSpec.describe JSON do
         expect(JSON.repair('{"a": "b\\')).to eq('{"a":"b"}')
       end
 
+      it 'repairs a string followed by a backslash-escaped delimiter' do
+        expect(JSON.repair('["y"\\, "z"]')).to eq('["y\\"","z"]')
+        expect(JSON.repair('"y"\\, "z"')).to eq('["y\\"","z"]')
+        expect(JSON.repair('{"a": "y"\\, "b": "z"}')).to eq('{"a":"y\\"","b":"z"}')
+      end
+
       it 'repairs ellipsis in an array' do
         expect(JSON.repair('[1,2,3,...]')).to eq('[1,2,3]')
         expect(JSON.repair('[1, 2, 3, ... ]')).to eq('[1,2,3]')


### PR DESCRIPTION
## Bug

`JSON.repair('["y"\, "z"]')` crashed with `SystemStackError` — violating the contract that `JSONRepairError` is the only error the library raises (the CLI already guards against it; library callers don't). Found by differential fuzzing during the 0.11.2 work and logged as a Tier 1 backlog item.

**Root cause:** `parse_string`'s missing-end-quote retry stops at the comma detected in the first pass (`stop_at_index`), but the invalid-escape repair consumed `\,` in a single two-character step (`@index += 2`), jumping straight over the stop index. The `@index == stop_at_index` check never fired, the parse reached the second quote again, and the comma path re-invoked `parse_string` with identical arguments forever.

Upstream [jsonrepair](https://github.com/josdejong/jsonrepair) has the same bug ("Maximum call stack size exceeded") as of v3.14.0, still its latest release as of today — so this is a local fix with divergence comments rather than an upstream sync. An upstream report is drafted separately.

## Fix

Two parts in `parse_string`, both commented as divergences:

1. **Targeted repair:** when the invalid-escape branch sees the escaped character sitting exactly at `stop_at_index`, drop just the backslash instead of consuming both characters, so the stop check fires at the delimiter and the comma keeps its delimiter role: `["y"\, "z"]` → `["y\"","z"]`. This is the only reachable straddle — `stop_at_index` always points at a comma, which cannot appear inside a valid escape or a `\u` hex run.
2. **Backstop:** the stop check is now `stop_at_index >= 0 && @index >= stop_at_index` (was `==`), guaranteeing termination even if a future upstream sync introduces a new multi-character advance. Dormant today; same comparison count on the hot path thanks to short-circuiting on the `-1` sentinel.

## Validation

- New spec (written first, watched it fail with the recursion): root, array, and object forms.
- Full suite: 189 examples, 0 failures, 100% line + branch coverage; RuboCop, RBS, and Steep clean.
- Differential vs main on a 240-input grid of escape-adjacent shapes: 26 diffs, **all** previously `SystemStackError`. 17 now repair sensibly; 9 (object shapes like `{"k": "y"\, "z"}`) raise the same "Colon expected" as their backslash-free analog `{"k": "y", "z"}`. Zero behavior changes to previously-working inputs.
- `rake bench` flat vs main (all four scenarios within 1%, inside ±7% error bars).

🤖 Generated with [Claude Code](https://claude.com/claude-code)