### PR TITLE
Repair the known Internal-error input families (0.12.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,36 @@
 # Changes
 
+### 2026-06-12 (0.12.0)
+
+* Repair the three known input families that raised `Internal error:
+  repaired output is not valid JSON` — cases where upstream
+  [jsonrepair](https://github.com/josdejong/jsonrepair) (v3.14.0, still
+  its latest release) emits invalid JSON and this gem's canonical
+  re-serialize guard caught it but blamed the Repairer. All three are
+  deliberate divergences from upstream, commented at each site:
+  * A stray `e`/`E` with no mantissa is now an unquoted string instead
+    of an empty-mantissa exponent: `[e]` → `["e"]`, `[e5]` → `["e5"]`,
+    `[truee]` → `[true,"e"]`, `{"k": e}` → `{"k":"e"}` (upstream emits
+    `e0` / raw `e5`). Numbers truncated at a real exponent (`[2e]` →
+    `[2.0]`) are unchanged.
+  * Negative leading-zero numbers are quoted like positive ones:
+    `{"n": -05}` → `{"n":"-05"}`, matching the existing `{"n": 05}` →
+    `{"n":"05"}` (upstream emits `-05` unrepaired). The same rule now
+    also covers the truncated-number repair, which bypassed it:
+    `[05e]` → `["05e0"]`, `00.` → `"00.0"` (upstream emits `05e0` /
+    `00.0` unrepaired). Valid `-0` / `-0.5` / `0e` / `0.` are
+    unchanged.
+  * The trailing-comma repair no longer strips a comma belonging to the
+    enclosing container when an inner object/array fails on its first
+    key or value: `[{{]` → `[{},{}]`, `[1,[}]` → `[1,[]]`,
+    `{"a": 1, "b": [}` → `{"a":1,"b":[]}` (upstream emits `[{}{}]`,
+    `[1[]]`, `{"a": 1 "b": []}`).
+  Validated by differential testing against upstream over a 270-input
+  grid of these shapes in every container context: the only behavior
+  changes vs 0.11.3 are the 123 previously-`Internal error` inputs now
+  repairing (or, for `e+` shapes where upstream emits invalid `e+0`,
+  raising a clean position-bearing error). Benchmarks flat.
+
 ### 2026-06-12 (0.11.3)
 
 * Fix infinite recursion (`SystemStackError`) on a quoted string

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    json-repair (0.11.3)
+    json-repair (0.12.0)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/json/repair/version.rb
+++ b/lib/json/repair/version.rb
@@ -2,6 +2,6 @@
 
 module JSON
   module Repair
-    VERSION = '0.11.3'
+    VERSION = '0.12.0'
   end
 end

--- a/lib/json/repairer.rb
+++ b/lib/json/repairer.rb
@@ -256,7 +256,7 @@ module JSON
           if @json[@index] == CLOSING_BRACE || @json[@index] == OPENING_BRACE ||
              @json[@index] == CLOSING_BRACKET || @json[@index] == OPENING_BRACKET ||
              @json[@index].nil?
-            # repair trailing comma — but only one this object's own loop
+            # repair trailing comma — but only the one this object's own loop
             # emitted or inserted; on the first pair the buffer's last
             # comma belongs to the enclosing container, like in [{{] or
             # {"a": 1, "b": {] (divergence from upstream, which strips
@@ -813,7 +813,7 @@ module JSON
           processed_value = parse_value
           next if processed_value
 
-          # repair trailing comma — but only one this array's own loop
+          # repair trailing comma — but only the one this array's own loop
           # emitted or inserted; on the first item the buffer's last
           # comma belongs to the enclosing container, like in [1,[}] or
           # {"a": 1, "b": [} (divergence from upstream, which strips

--- a/lib/json/repairer.rb
+++ b/lib/json/repairer.rb
@@ -767,7 +767,9 @@ module JSON
       if @index > start
         # repair a number with leading zeros like "00789"
         num = @json[start...@index]
-        has_invalid_leading_zero = num.match?(/^0\d/)
+        # the optional sign quotes "-05" like "05" (divergence from
+        # upstream, whose unsigned check lets "-05" through unrepaired)
+        has_invalid_leading_zero = num.match?(/^-?0\d/)
 
         @output << (has_invalid_leading_zero ? "\"#{num}\"" : repair_leading_dot_number(num))
         return true
@@ -865,7 +867,11 @@ module JSON
       # repair numbers cut off at the end
       # this will only be called when we end after a '.', '-', or 'e' and does not
       # change the number more than it needs to make it valid JSON
-      @output << repair_leading_dot_number("#{@json[start...@index]}0")
+      num = "#{@json[start...@index]}0"
+      # quote a padded token that has an invalid leading zero, like "05e" ->
+      # "05e0", applying the same rule as the end of parse_number (divergence
+      # from upstream, which emits the invalid number raw)
+      @output << (num.match?(/^-?0\d/) ? "\"#{num}\"" : repair_leading_dot_number(num))
     end
 
     # Repair a number missing its digit before the decimal point, like ".5"

--- a/lib/json/repairer.rb
+++ b/lib/json/repairer.rb
@@ -237,6 +237,7 @@ module JSON
 
       initial = true
       while @index < @json.length && @json[@index] != CLOSING_BRACE
+        first_pair = initial
         if initial
           initial = false
         else
@@ -255,8 +256,12 @@ module JSON
           if @json[@index] == CLOSING_BRACE || @json[@index] == OPENING_BRACE ||
              @json[@index] == CLOSING_BRACKET || @json[@index] == OPENING_BRACKET ||
              @json[@index].nil?
-            # repair trailing comma
-            @output = strip_last_occurrence(@output, ',')
+            # repair trailing comma — but only one this object's own loop
+            # emitted or inserted; on the first pair the buffer's last
+            # comma belongs to the enclosing container, like in [{{] or
+            # {"a": 1, "b": {] (divergence from upstream, which strips
+            # the parent's comma and emits invalid JSON like [{}{}])
+            @output = strip_last_occurrence(@output, ',') unless first_pair
           else
             throw_object_key_expected
           end
@@ -794,6 +799,7 @@ module JSON
 
         initial = true
         while @index < @json.length && @json[@index] != CLOSING_BRACKET
+          first_item = initial
           if initial
             initial = false
           else
@@ -807,8 +813,12 @@ module JSON
           processed_value = parse_value
           next if processed_value
 
-          # repair trailing comma
-          @output = strip_last_occurrence(@output, ',')
+          # repair trailing comma — but only one this array's own loop
+          # emitted or inserted; on the first item the buffer's last
+          # comma belongs to the enclosing container, like in [1,[}] or
+          # {"a": 1, "b": [} (divergence from upstream, which strips
+          # the parent's comma and emits invalid JSON like [1[]])
+          @output = strip_last_occurrence(@output, ',') unless first_item
           break
         end
 

--- a/lib/json/repairer.rb
+++ b/lib/json/repairer.rb
@@ -738,7 +738,13 @@ module JSON
         @index += 1 while digit?(@json[@index])
       end
 
-      if @json[@index] && @json[@index].downcase == 'e'
+      # Divergence from upstream: only enter the exponent branch when a
+      # mantissa was consumed — at this point @index > start implies at
+      # least one digit (the '-' and '.' paths reset otherwise). Upstream
+      # accepts a bare "e"/"E" here and emits invalid JSON like `e0` or
+      # raw `e5`; declining lets the token fall through to
+      # parse_unquoted_string, matching how "-e5" already becomes "-e5".
+      if @index > start && @json[@index] && @json[@index].downcase == 'e'
         @index += 1
         @index += 1 if ['-', '+'].include?(@json[@index])
         if at_end_of_number?

--- a/spec/json/repair/string_utils_spec.rb
+++ b/spec/json/repair/string_utils_spec.rb
@@ -3,6 +3,12 @@
 RSpec.describe JSON::Repair::StringUtils do
   let(:host) { JSON::Repairer.new('') }
 
+  describe '#strip_last_occurrence' do
+    it 'returns the text unchanged when the character is not present' do
+      expect(host.strip_last_occurrence('abc', ',')).to eq('abc')
+    end
+  end
+
   describe '#special_whitespace?' do
     it 'returns false when char is nil' do
       expect(host.special_whitespace?(nil)).to be(false)

--- a/spec/json_spec.rb
+++ b/spec/json_spec.rb
@@ -701,6 +701,24 @@ RSpec.describe JSON do
         expect(JSON.repair('[-., 1]')).to eq('[-0.0,1]')
       end
 
+      it 'repairs a stray e or E into an unquoted string' do
+        expect(JSON.repair('[e]')).to eq('["e"]')
+        expect(JSON.repair('[E]')).to eq('["E"]')
+        expect(JSON.repair('[e5]')).to eq('["e5"]')
+        expect(JSON.repair('[E5]')).to eq('["E5"]')
+        expect(JSON.repair('e')).to eq('"e"')
+        expect(JSON.repair('[e, 1]')).to eq('["e",1]')
+        expect(JSON.repair('[e-]')).to eq('["e-"]')
+        expect(JSON.repair('{"k": e}')).to eq('{"k":"e"}')
+        expect(JSON.repair('[truee]')).to eq('[true,"e"]')
+        expect(JSON.repair('["z"e]')).to eq('["z","e"]')
+        # the concatenation path declines after the stray e, like [a+]
+        expect { JSON.repair('[e+]') }.to \
+          raise_error(JSON::JSONRepairError, 'Unexpected character "+" at index 2')
+        # a real mantissa + e + non-digit/non-end also falls through to unquoted string
+        expect(JSON.repair('[2ex]')).to eq('["2ex"]')
+      end
+
       it 'repairs an object with an unquoted key and unclosed array value' do
         expect(JSON.repair('{foo: [}')).to eq('{"foo":[]}')
       end

--- a/spec/json_spec.rb
+++ b/spec/json_spec.rb
@@ -747,6 +747,23 @@ RSpec.describe JSON do
         expect(JSON.repair('{foo: [}')).to eq('{"foo":[]}')
       end
 
+      it 'repairs a truncated nested container without dropping the enclosing comma' do
+        expect(JSON.repair('[{{]')).to eq('[{},{}]')
+        expect(JSON.repair('["x",{{]')).to eq('["x",{},{}]')
+        expect(JSON.repair('[{"a":1,{]')).to eq('[{"a":1},{}]')
+        expect(JSON.repair('[1,[}]')).to eq('[1,[]]')
+        expect(JSON.repair('[1,[}')).to eq('[1,[]]')
+        expect(JSON.repair('{"a": 1, "b": [}')).to eq('{"a":1,"b":[]}')
+        expect(JSON.repair('{"a": 1, "b": {]')).to eq('{"a":1,"b":{}}')
+        # doubled braces at the root still raise (no enclosing comma to lose)
+        expect { JSON.repair('{{') }.to \
+          raise_error(JSON::JSONRepairError, 'Unexpected character "{" at index 1')
+        expect { JSON.repair('{{}}') }.to \
+          raise_error(JSON::JSONRepairError, 'Unexpected character "{" at index 1')
+        expect { JSON.repair('{"a":{{') }.to \
+          raise_error(JSON::JSONRepairError, 'Unexpected character "{" at index 6')
+      end
+
       it 'repairs a value behind a Markdown list marker' do
         expect(JSON.repair('- { "k": 1 }')).to eq('{"k":1}')
         expect(JSON.repair('- [1, 2]')).to eq('[1,2]')

--- a/spec/json_spec.rb
+++ b/spec/json_spec.rb
@@ -688,6 +688,30 @@ RSpec.describe JSON do
         expect(JSON.repair('{value:0789}')).to eq('{"value":"0789"}')
       end
 
+      it 'repairs a negative number with leading zero' do
+        expect(JSON.repair('-05')).to eq('"-05"')
+        expect(JSON.repair('-0789')).to eq('"-0789"')
+        expect(JSON.repair('[-05]')).to eq('["-05"]')
+        expect(JSON.repair('[-05e3]')).to eq('["-05e3"]')
+        expect(JSON.repair('{"n": -05}')).to eq('{"n":"-05"}')
+        # valid negative-zero numbers are untouched
+        expect(JSON.repair('[-0]')).to eq('[0]')
+        expect(JSON.repair('[-0.5]')).to eq('[-0.5]')
+      end
+
+      it 'repairs a truncated number with leading zero' do
+        expect(JSON.repair('[05e]')).to eq('["05e0"]')
+        expect(JSON.repair('00e')).to eq('"00e0"')
+        expect(JSON.repair('00.')).to eq('"00.0"')
+        expect(JSON.repair('[-05e]')).to eq('["-05e0"]')
+        expect(JSON.repair('-00.')).to eq('"-00.0"')
+        # a single leading zero stays numeric after padding
+        expect(JSON.repair('[0e]')).to eq('[0.0]')
+        expect(JSON.repair('[0.]')).to eq('[0.0]')
+        expect(JSON.repair('[-0e]')).to eq('[-0.0]')
+        expect(JSON.repair('[-0.]')).to eq('[-0.0]')
+      end
+
       it 'repairs a number starting with a dot' do
         expect(JSON.repair('.5')).to eq('0.5')
         expect(JSON.repair('-.5')).to eq('-0.5')


### PR DESCRIPTION
## Summary

Eliminates the three known input families that raised `Internal error: repaired output is not valid JSON` — cases where upstream jsonrepair (v3.14.0, still its latest release) emits invalid JSON and this gem's canonical re-serialize guard caught it but blamed the Repairer. All three are deliberate divergences from upstream, commented at each site:

- **Stray `e`/`E` with no mantissa** becomes an unquoted string instead of an empty-mantissa exponent: `[e]` → `["e"]`, `[e5]` → `["e5"]`, `[truee]` → `[true,"e"]`, `{"k": e}` → `{"k":"e"}` (upstream emits `e0` / raw `e5`). Numbers truncated at a real exponent (`[2e]` → `[2.0]`) are unchanged.
- **Leading-zero quoting now covers the sign and the truncated-number path**: `{"n": -05}` → `{"n":"-05"}` matching the existing `{"n": 05}` → `{"n":"05"}`, and `[05e]` → `["05e0"]`, `00.` → `"00.0"` via `repair_number_ending_with_numeric_symbol`, which previously bypassed the rule (upstream emits `-05` / `05e0` unrepaired). Valid `-0` / `-0.5` / `0e` / `0.` unchanged.
- **The trailing-comma repair no longer strips the enclosing container's comma** when an inner object/array fails on its first key or value: `[{{]` → `[{},{}]`, `[1,[}]` → `[1,[]]`, `{"a": 1, "b": [}` → `{"a":1,"b":[]}` (upstream emits `[{}{}]`, `[1[]]`, `{"a": 1 "b": []}`).

Validated by differential testing against upstream jsonrepair@3.14.0 over a 270-input grid of these shapes in every container context: the only behavior changes vs 0.11.3 are the 123 previously-`Internal error` inputs now repairing (or, for `e+` shapes where upstream emits invalid `e+0`, raising a clean position-bearing error). Benchmarks flat.

## Test Plan

- [x] `bundle exec rake` — RSpec (194 examples, 100% line + branch coverage), RuboCop, RBS validate, Steep all green
- [x] Differential vs upstream jsonrepair@3.14.0 and vs main (270-input grid): zero unexpected diffs, zero crashes
- [x] `bundle exec rake bench` before/after: flat (all scenarios within noise)

🤖 Generated with [Claude Code](https://claude.com/claude-code)