### PR TITLE
Pin every-prefix repairability of a reference document

### DIFF
--- a/spec/json_spec.rb
+++ b/spec/json_spec.rb
@@ -200,6 +200,30 @@ RSpec.describe JSON do
         expect(JSON.repair('{"a": "b\\')).to eq('{"a":"b"}')
       end
 
+      it 'repairs every prefix of a reference document into parseable JSON' do
+        doc = <<~'JSON'
+          {
+            "id": 42,
+            "name": "héllo — ☃",
+            "esc": "quote:\" back:\\ nl:\n uni:\u2605",
+            "nums": [-0.25, 1.5e-3, 1000],
+            "nested": {
+              "arr": [1, [2, {"deep": true}]],
+              "ok": false,
+              "nil": null
+            }
+          }
+        JSON
+
+        expect(JSON.parse(JSON.repair(doc))).to eq(JSON.parse(doc))
+
+        (1..doc.length).each do |i|
+          prefix = doc[0, i]
+          expect { JSON.parse(JSON.repair(prefix)) }.not_to \
+            raise_error, "failed at prefix length #{i}: #{prefix.inspect}"
+        end
+      end
+
       it 'repairs a string followed by a backslash-escaped delimiter' do
         expect(JSON.repair('["y"\\, "z"]')).to eq('["y\\"","z"]')
         expect(JSON.repair('"y"\\, "z"')).to eq('["y\\"","z"]')


### PR DESCRIPTION
## Summary
- Adds one property-style pinning example to `spec/json_spec.rb`: every prefix (lengths `1..doc.length`) of a reference JSON document must repair into output stdlib `JSON.parse` accepts — cheap insurance for the truncation paths hardened in 0.11.x/0.12.0 (idea from untruncate-json's suite).
- The reference doc packs nested containers, literal `\"`/`\\`/`\n`/`\u2605` escapes, real multibyte unicode, negative/exponent/integer numbers, and `true`/`false`/`null`; a fixture-guard assertion also pins that the complete doc survives repair value-intact.
- Test-only: no `lib/`, `sig/`, README, or CHANGELOG changes.

## Test Plan
- [x] Red step proved the assertion fires: loop written from prefix length 0 fails at the deliberately-raising empty prefix, then corrected to start at 1.
- [x] `bundle exec rake` fully green: 195 examples, 0 failures, SimpleCov 100% line (651/651) and branch (270/270) coverage, RuboCop, `rbs validate`, Steep all clean.
- [x] Example runtime ~35 ms (~233 repair calls); suite runtime unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
