### PR TITLE
Repair # hash line comments (0.13.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changes
 
+### 2026-06-12 (0.13.0)
+
+* Repair `#` hash line comments, like in Python, YAML, or Hjson:
+  `{"a": 1 # comment\n}` → `{"a":1}`, `{ # note\n "a": 1}` →
+  `{"a":1}`, `# lead\n{"a": 1}` → `{"a":1}`. Divergence from upstream
+  [jsonrepair](https://github.com/josdejong/jsonrepair) (v3.14.0
+  raises on all of these), commented at the site. Recognition is
+  context-aware so unquoted values starting with `#` keep repairing
+  into strings — `{"color": #ff0000}` → `{"color":"#ff0000"}`,
+  `{#tag: 1}` → `{"#tag":1}`, `#standalone` → `"#standalone"` — where
+  Python's `json_repair` silently loses them (`{"color": ""}`).
+  Where a value or key is expected, a `#` token reaching a structural
+  delimiter (`,` `}` `]` `:`) before any whitespace, or running to
+  end-of-input without a newline, stays a value; anything else is a
+  comment stripped to the end of the line. The tradeoff: a `#` token
+  followed by whitespace or a newline at a value position now reads
+  as a comment — `{"a": #b c}` → `{"a":null}` and `{"a": #tag\n}` →
+  `{"a":null}`, where 0.12.0 kept them as strings (Python drops them
+  too), and a comment-only document now raises like `// only a
+  comment` always has. Pinned in the spec suite as conscious
+  decisions.
+
 ### 2026-06-12 (0.12.0)
 
 * Repair the three known input families that raised `Internal error:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    json-repair (0.12.0)
+    json-repair (0.13.0)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/json/repair/version.rb
+++ b/lib/json/repair/version.rb
@@ -2,6 +2,6 @@
 
 module JSON
   module Repair
-    VERSION = '0.12.0'
+    VERSION = '0.13.0'
   end
 end

--- a/lib/json/repairer.rb
+++ b/lib/json/repairer.rb
@@ -71,7 +71,7 @@ module JSON
       # repair redundant end quotes
       while [CLOSING_BRACE, CLOSING_BRACKET].include?(@json[@index])
         @index += 1
-        parse_whitespace_and_skip_comments
+        parse_whitespace_and_skip_comments(value_expected: false)
       end
 
       if @index >= @json.length
@@ -93,17 +93,17 @@ module JSON
                 parse_keywords ||
                 parse_unquoted_string(false) ||
                 parse_regex
-      parse_whitespace_and_skip_comments
+      parse_whitespace_and_skip_comments(value_expected: false)
 
       process
     end
 
-    def parse_whitespace_and_skip_comments(skip_newline: true)
+    def parse_whitespace_and_skip_comments(skip_newline: true, value_expected: true)
       start = @index
 
       changed = parse_whitespace(skip_newline: skip_newline)
       loop do
-        changed = parse_comment
+        changed = parse_comment(value_expected: value_expected)
         changed = parse_whitespace(skip_newline: skip_newline) if changed
         break unless changed
       end
@@ -131,7 +131,7 @@ module JSON
       false
     end
 
-    def parse_comment
+    def parse_comment(value_expected: true)
       if @json[@index] == '/' && @json[@index + 1] == '*'
         # Block comment
         @index += 2
@@ -143,9 +143,40 @@ module JSON
         @index += 2
         @index += 1 until @json[@index].nil? || @json[@index] == "\n"
         true
+      elsif @json[@index] == '#' && hash_comment?(value_expected)
+        # Hash line comment, like in Python, YAML, or Hjson (divergence
+        # from upstream, which raises on `#` as of v3.14.0)
+        @index += 1
+        @index += 1 until @json[@index].nil? || @json[@index] == "\n"
+        true
       else
         false
       end
+    end
+
+    # Decide whether the `#` at @index starts a line comment or an
+    # unquoted value like {"color": #ff0000}, {#tag: 1}, or a root
+    # #hashtag (which Python's json_repair eats as comments, losing
+    # data). Where no value or key is expected an unquoted token would
+    # be junk anyway, so `#` is always a comment, exactly like `//`.
+    # Where one is expected, scan the rest of the line: a structural
+    # delimiter (`,` `}` `]` `:`) before any whitespace means the token
+    # reads as a value in context; whitespace (including the newline
+    # itself) first means comment prose; reaching EOF without a newline
+    # keeps the token a value, so truncated input like {"a": #tag is
+    # repaired, not dropped. Divergence from upstream, as above.
+    def hash_comment?(value_expected)
+      return true unless value_expected
+
+      i = @index + 1
+      while (char = @json[i])
+        return true if whitespace_or_special?(char)
+        return false if [COMMA, COLON, CLOSING_BRACE, CLOSING_BRACKET].include?(char)
+
+        i += 1
+      end
+
+      false
     end
 
     # Find and skip over a Markdown fenced code block:
@@ -268,7 +299,7 @@ module JSON
           break
         end
 
-        parse_whitespace_and_skip_comments
+        parse_whitespace_and_skip_comments(value_expected: false)
         processed_colon = parse_character(COLON)
         truncated_text = @index >= @json.length
         unless processed_colon
@@ -491,7 +522,7 @@ module JSON
           @index += 1
           @output << str
 
-          parse_whitespace_and_skip_comments(skip_newline: false)
+          parse_whitespace_and_skip_comments(skip_newline: false, value_expected: false)
 
           if stop_at_delimiter ||
              @index >= @json.length ||
@@ -846,11 +877,11 @@ module JSON
     def parse_concatenated_string
       processed = false
 
-      parse_whitespace_and_skip_comments
+      parse_whitespace_and_skip_comments(value_expected: false)
       while @json[@index] == PLUS
         processed = true
         @index += 1
-        parse_whitespace_and_skip_comments
+        parse_whitespace_and_skip_comments(value_expected: false)
 
         # repair: remove the end quote of the first string
         @output = strip_last_occurrence(@output, '"', strip_remaining_text: true)

--- a/sig/json/repairer.rbs
+++ b/sig/json/repairer.rbs
@@ -37,7 +37,9 @@ module JSON
 
     def parse_whitespace: (?skip_newline: bool) -> bool
 
-    def parse_comment: () -> bool
+    def parse_comment: (?value_expected: bool) -> bool
+
+    def hash_comment?: (bool value_expected) -> bool
 
     # Find and skip over a Markdown fenced code block
     def parse_markdown_code_block: (::Array[::String] blocks) -> bool
@@ -87,7 +89,7 @@ module JSON
 
     def parse_character: (::String char) -> bool
 
-    def parse_whitespace_and_skip_comments: (?skip_newline: bool) -> bool
+    def parse_whitespace_and_skip_comments: (?skip_newline: bool, ?value_expected: bool) -> bool
 
     # Parse a number like 2.4 or 2.4e6
     def parse_number: () -> bool

--- a/spec/json_spec.rb
+++ b/spec/json_spec.rb
@@ -419,6 +419,22 @@ RSpec.describe JSON do
         expect(JSON.repair("{\"a\": 1}\n# trailing")).to eq('{"a":1}')
         expect(JSON.repair("{\"a\":1}\n{\"b\":2} # note")).to eq('[{"a":1},{"b":2}]')
         expect(JSON.repair("\"a\" + # note\n \"b\"")).to eq('"ab"')
+        expect(JSON.repair("{\"a\":1}\n# note\n{\"b\":2}")).to eq('[{"a":1},{"b":2}]')
+        expect(JSON.repair("{\"a\": 1 # c\r\n, \"b\": 2}")).to eq('{"a":1,"b":2}')
+        expect(JSON.repair('{"a": 1 #')).to eq('{"a":1}')
+        expect(JSON.repair('"a" + #note')).to eq('"a"')
+      end
+
+      it 'treats whitespace-bearing # tokens at value positions as comments' do
+        # the flip side of the lookahead: once whitespace follows the #
+        # before any structural delimiter, the token reads as comment
+        # prose, even where a value is expected — a conscious tradeoff
+        # (Python's json_repair drops these too), pinned so a future
+        # change can't flip it silently
+        expect(JSON.repair('{"a": #b c}')).to eq('{"a":null}')
+        expect(JSON.repair("{\"a\": #tag\n}")).to eq('{"a":null}')
+        expect { JSON.repair("# note\n") }.to \
+          raise_error(JSON::JSONRepairError, 'Unexpected end of json string at index 7')
       end
 
       it 'does not remove comments inside a string' do

--- a/spec/json_spec.rb
+++ b/spec/json_spec.rb
@@ -384,6 +384,43 @@ RSpec.describe JSON do
           eq('{"a":"foo","b":"bar"}')
       end
 
+      it 'keeps unquoted values starting with #' do
+        # the hash-comment lookahead (see hash_comment?) must leave these
+        # repairs untouched; Python's json_repair eats them as comments
+        # and loses the data
+        expect(JSON.repair('{"color": #ff0000}')).to eq('{"color":"#ff0000"}')
+        expect(JSON.repair('{"tag": #hashtag}')).to eq('{"tag":"#hashtag"}')
+        expect(JSON.repair('["#a", #b]')).to eq('["#a","#b"]')
+        expect(JSON.repair('["#a", #b, "c"]')).to eq('["#a","#b","c"]')
+        expect(JSON.repair('{#tag: 1}')).to eq('{"#tag":1}')
+        expect(JSON.repair('#standalone')).to eq('"#standalone"')
+        expect(JSON.repair('{"a": #tag')).to eq('{"a":"#tag"}')
+      end
+
+      it 'does not remove # inside a string' do
+        expect(JSON.repair('"# not a comment"')).to eq('"# not a comment"')
+        expect(JSON.repair('{"a": "x # y"')).to eq('{"a":"x # y"}')
+      end
+
+      it 'removes # line comments' do
+        # divergence from upstream, which raises on # as of v3.14.0;
+        # see the # branch in parse_comment
+        expect(JSON.repair("{\"a\": 1 # comment\n}")).to eq('{"a":1}')
+        expect(JSON.repair('{"a": 1 # comment}')).to eq('{"a":1}')
+        expect(JSON.repair('[1, 2 # comment]')).to eq('[1,2]')
+        expect(JSON.repair("[\"a\" # note\n, \"b\"]")).to eq('["a","b"]')
+        expect(JSON.repair("{ # note\n \"a\": 1}")).to eq('{"a":1}')
+        expect(JSON.repair("{ #TODO\n \"a\": 1}")).to eq('{"a":1}')
+        expect(JSON.repair("{\"a\": 1, # b\n \"c\": 2}")).to eq('{"a":1,"c":2}')
+        expect(JSON.repair("{\"a\": # note\n 1}")).to eq('{"a":1}')
+        expect(JSON.repair("{\"a\" # c\n: 1}")).to eq('{"a":1}')
+        expect(JSON.repair("# lead\n{\"a\": 1}")).to eq('{"a":1}')
+        expect(JSON.repair("{ # a\n # b\n \"x\": 1}")).to eq('{"x":1}')
+        expect(JSON.repair("{\"a\": 1}\n# trailing")).to eq('{"a":1}')
+        expect(JSON.repair("{\"a\":1}\n{\"b\":2} # note")).to eq('[{"a":1},{"b":2}]')
+        expect(JSON.repair("\"a\" + # note\n \"b\"")).to eq('"ab"')
+      end
+
       it 'does not remove comments inside a string' do
         expect(JSON.repair('"/* foo */"')).to eq('"/* foo */"')
       end


### PR DESCRIPTION
## Summary

Repairs `#` hash line comments, like in Python, YAML, or Hjson — the next Tier 1 backlog item. `{"a": 1 # comment\n}` and `{ # note\n "a": 1}` previously raised; `[1, 2 # comment]` and `# lead\n{"a": 1}` silently mangled. Deliberate divergence from upstream jsonrepair (v3.14.0 raises on all of these — `#` is out of scope for its grammar; no upstream issue filed), commented at the site.

Recognition is **context-aware** so unquoted values starting with `#` keep repairing into strings — the watch-out called out in the backlog item. Python's `json_repair` supports `#` comments but silently destroys these values (`{"color": #ff0000}` → `{"color": ""}`); this implementation preserves them:

- **Where no value/key is expected** (after a value, before `,`/`}`/`]`, after a key, root tail): `#` is always a line comment, with exact `//` semantics — including self-healing an unterminated `{"a": 1 # comment}` via the unclosed-container repair, and CRLF inputs.
- **Where a value/key is expected**: a lookahead (`hash_comment?`) scans the rest of the line. A structural delimiter (`,` `}` `]` `:`) before any whitespace reads as a value in context (`{"color": #ff0000}` → `{"color":"#ff0000"}`, `{#tag: 1}` → `{"#tag":1}`, `["#a", #b]` → `["#a","#b"]`); reaching EOF without a newline keeps the token a value, so truncated `{"a": #tag` → `{"a":"#tag"}` is repaired, not dropped; anything else is comment prose (`{ # note\n "a": 1}`, `{ #TODO\n …}`, `# see http://x, also y`).
- **The tradeoff, pinned as conscious decisions**: whitespace-bearing `#` tokens at value positions now read as comments — `{"a": #b c}` → `{"a":null}` and `{"a": #tag\n}` → `{"a":null}` where 0.12.0 kept them as strings (Python drops them too), and a comment-only document now raises like `// only a comment` always has.

Mechanically: a `value_expected:` keyword threaded through `parse_whitespace_and_skip_comments` (six after-value call sites pass `false`; the twelve value/key-expected sites keep the guarded default), a `#` branch in `parse_comment`, and the `hash_comment?` helper. `#` inside strings is untouched for free (`parse_comment` never runs inside `parse_string`). `//` and `/* */` behavior is byte-identical at every site; non-`#` inputs are structurally unaffected.

Note for review: the RBS signatures land in the third commit, so the two earlier commits aren't Steep-clean in isolation — fine under this repo's squash-merge convention, but `git bisect` with `rake` would trip on them.

## Test Plan

- [x] `bundle exec rake` — RSpec (199 examples, 100% line + branch coverage), RuboCop, RBS validate, Steep all green
- [x] 30 new spec expectations: comment placements (after-value, standalone-line, between-pairs, pre-value, pre-colon, leading, trailing, NDJSON interior, CRLF, concatenation), value preservation (each structural delimiter individually, EOF, key position, truncation), in-string `#` safety, and the pinned tradeoff flips
- [x] Behavior verified against upstream jsonrepair@3.14.0 (raises), Python json_repair (loses `#`-values), and 0.12.0 (all six preserved-value shapes byte-identical)
- [x] `bundle exec rake bench` before/after: flat (all scenarios within noise; largest delta -3.3% on broken_llm_style vs ±6.8% error bars)

🤖 Generated with [Claude Code](https://claude.com/claude-code)