### PR TITLE
Repair a leading + on numbers (0.14.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changes
 
+### 2026-06-17 (0.14.0)
+
+* Repair a leading `+` on numbers, like in JSON5: `+1.23` → `1.23`,
+  `[+1]` → `[1]`, `{"a": +5}` → `{"a":5}`, `+.5` → `0.5`. The `+` is
+  consumed and dropped (JSON has no explicit plus), so a leading-zero
+  number is quoted exactly like its unsigned form (`+05` → `"05"`),
+  while a `+` inside an exponent is left untouched (`2e+5` →
+  `200000.0`). The `+` must be followed by a digit or a leading dot, so
+  a bare `+` (and `+abc`, `++1`, `+e5`) still raises — and requiring a
+  digit/dot keeps the 0.12.0 empty-mantissa exponent guard intact.
+  Divergence from upstream
+  [jsonrepair](https://github.com/josdejong/jsonrepair) (v3.14.0 leaves
+  `+1.23` unrepaired, raising "Unexpected end of json string"),
+  commented at the site. Mirrors the leading-dot number repair (0.9.0).
+
 ### 2026-06-12 (0.13.0)
 
 * Repair `#` hash line comments, like in Python, YAML, or Hjson:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    json-repair (0.13.0)
+    json-repair (0.14.0)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/json/repair/version.rb
+++ b/lib/json/repair/version.rb
@@ -2,6 +2,6 @@
 
 module JSON
   module Repair
-    VERSION = '0.13.0'
+    VERSION = '0.14.0'
   end
 end

--- a/lib/json/repairer.rb
+++ b/lib/json/repairer.rb
@@ -741,6 +741,24 @@ module JSON
     # Parse a number like 2.4 or 2.4e6
     def parse_number
       start = @index
+
+      # Divergence from upstream: accept and discard a leading "+". JSON5
+      # permits an explicit plus; JSON does not, so "+1.23" -> "1.23" and
+      # "{"a": +5}" -> {"a":5}. The "+" must be followed by a digit or a
+      # leading dot (mirroring the "-" branch below); otherwise this is not
+      # a number and we backtrack to the "+" so a bare "+" still raises.
+      # `start` stays on the "+", so the reset paths restore @index cleanly
+      # and the @index > start exponent guard below still implies a digit
+      # was consumed; the two emission sites drop the leading "+" before
+      # quoting. Upstream leaves "+1.23" unrepaired.
+      if @json[@index] == PLUS
+        @index += 1
+        unless digit?(@json[@index]) || @json[@index] == DOT
+          @index = start
+          return false
+        end
+      end
+
       if @json[@index] == '-'
         @index += 1
         if at_end_of_number?
@@ -802,7 +820,9 @@ module JSON
 
       if @index > start
         # repair a number with leading zeros like "00789"
-        num = @json[start...@index]
+        # drop a leading "+" first (see the PLUS branch above), so "+05"
+        # quotes like "05" and "+1.23" emits as "1.23"
+        num = @json[start...@index].delete_prefix(PLUS)
         # the optional sign quotes "-05" like "05" (divergence from
         # upstream, whose unsigned check lets "-05" through unrepaired)
         has_invalid_leading_zero = num.match?(/^-?0\d/)
@@ -908,7 +928,8 @@ module JSON
       # repair numbers cut off at the end
       # this will only be called when we end after a '.', '-', or 'e' and does not
       # change the number more than it needs to make it valid JSON
-      num = "#{@json[start...@index]}0"
+      # delete_prefix drops a leading "+" (see the PLUS branch in parse_number)
+      num = "#{@json[start...@index]}0".delete_prefix(PLUS)
       # quote a padded token that has an invalid leading zero, like "05e" ->
       # "05e0", applying the same rule as the end of parse_number (divergence
       # from upstream, which emits the invalid number raw)

--- a/spec/json_spec.rb
+++ b/spec/json_spec.rb
@@ -825,6 +825,11 @@ RSpec.describe JSON do
         expect { JSON.repair('+') }.to raise_error(JSON::JSONRepairError)
         expect { JSON.repair('[+]') }.to raise_error(JSON::JSONRepairError)
         expect { JSON.repair('+abc') }.to raise_error(JSON::JSONRepairError)
+        # a doubled sign is not a number
+        expect { JSON.repair('++1') }.to raise_error(JSON::JSONRepairError)
+        # the digit/dot-after-plus guard keeps the 0.12.0 empty-mantissa
+        # exponent guard intact: +e5 must raise, not emit an invalid "e0"
+        expect { JSON.repair('+e5') }.to raise_error(JSON::JSONRepairError)
       end
 
       it 'repairs a stray e or E into an unquoted string' do

--- a/spec/json_spec.rb
+++ b/spec/json_spec.rb
@@ -802,6 +802,31 @@ RSpec.describe JSON do
         expect(JSON.repair('[-., 1]')).to eq('[-0.0,1]')
       end
 
+      it 'repairs a number with a leading plus' do
+        expect(JSON.repair('+1.23')).to eq('1.23')
+        expect(JSON.repair('+5')).to eq('5')
+        expect(JSON.repair('[+1]')).to eq('[1]')
+        expect(JSON.repair('[+1, +2]')).to eq('[1,2]')
+        expect(JSON.repair('{"a": +5}')).to eq('{"a":5}')
+        expect(JSON.repair('+.5')).to eq('0.5')
+        # the leading + is dropped, so a leading-zero number is quoted just
+        # like its plain "05" form
+        expect(JSON.repair('+05')).to eq('"05"')
+        # a + inside the exponent is part of the number and left untouched
+        expect(JSON.repair('2e+5')).to eq('200000.0')
+      end
+
+      it 'repairs a number cut off after a leading plus' do
+        expect(JSON.repair('+.')).to eq('0.0')
+        expect(JSON.repair('[+1.]')).to eq('[1.0]')
+      end
+
+      it 'raises on a bare plus that is not a number' do
+        expect { JSON.repair('+') }.to raise_error(JSON::JSONRepairError)
+        expect { JSON.repair('[+]') }.to raise_error(JSON::JSONRepairError)
+        expect { JSON.repair('+abc') }.to raise_error(JSON::JSONRepairError)
+      end
+
       it 'repairs a stray e or E into an unquoted string' do
         expect(JSON.repair('[e]')).to eq('["e"]')
         expect(JSON.repair('[E]')).to eq('["E"]')


### PR DESCRIPTION
## Summary

`+1.23` raised `Unexpected end of json string` (Tier 1 backlog item; upstream-shared — [jsonrepair](https://github.com/josdejong/jsonrepair) v3.14.0 leaves it unrepaired too). [JSON5](https://json5.org/) permits an explicit plus on numbers, so this accepts and **drops** the `+`:

```ruby
JSON.repair('+1.23')        # => '1.23'
JSON.repair('[+1]')         # => '[1]'
JSON.repair('{"a": +5}')    # => '{"a":5}'
JSON.repair('+.5')          # => '0.5'
```

Deliberate divergence from upstream, commented at the site. Mirrors the leading-dot number repair (0.9.0).

## Behavior

| input | output | note |
| --- | --- | --- |
| `+1.23`, `+5`, `[+1]`, `{"a": +5}` | `1.23`, `5`, `[1]`, `{"a":5}` | `+` dropped |
| `+.5` | `0.5` | composes with leading-dot repair |
| `+05` | `"05"` | `+` dropped, then quoted like any leading-zero number |
| `2e+5` | `200000.0` | a `+` **inside** an exponent is part of the number, untouched |
| `+`, `+abc`, `++1`, `+e5` | raise | `+` not followed by a digit/dot is not a number |

## Implementation

`parse_number` gains a leading-`+` branch mirroring the existing `-` branch. Two subtleties:

1. **`start` stays on the `+`.** The reset paths (`@index = start; return false`) then restore `@index` to before the `+`, so a non-number like `+abc` backtracks cleanly and the parse-method contract (false ⇒ nothing consumed) holds.
2. **The `+` must be followed by a digit or a leading dot.** This is what keeps the 0.12.0 empty-mantissa exponent guard (`@index > start` ⇒ a digit was consumed) intact — without it, `+e5` would reach the exponent branch with no mantissa and emit an invalid `e0`. With it, `+e5` raises instead.

The two number-emission sites (`parse_number`'s tail and `repair_number_ending_with_numeric_symbol`) strip the leading `+` via `delete_prefix` before the leading-zero check, so `+05` → `"05"`.

## Verification

- **TDD**: three new examples in `spec/json_spec.rb` (leading plus, cut-off-after-plus, bare-plus raises). Watched them fail first.
- **Full suite**: 202 examples, 0 failures, 100% line + branch coverage.
- **Differential vs main** on a 194-input sign/number grid (`''`/`+`/`-`/`++`/`+-`/`-+` × number bodies, wrapped in arrays/objects): every diff is a `+`-prefixed token going from *raise* to a correct repair; **zero non-`+` changes**.
- **Bench flat** across all four `rake bench` scenarios (within run-to-run noise).
- `rubocop`, `rbs validate`, `steep check` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)